### PR TITLE
fix(renovate): change renovate config path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,15 +1,4 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'github>ykzts/ykzts//.github/renovate.json',
-    'customManagers:dockerfileVersions',
-  ],
-  packageRules: [
-    {
-      groupName: 'immich docker containers',
-      groupSlug: 'immich',
-      matchDatasources: ['docker'],
-      matchPackageNames: ['ghcr.io/immich-app/**'],
-    },
-  ],
+  extends: ['github>ykzts/ykzts//renovate-config/default.json5'],
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to use a new shared config and removes custom rules and managers. The main change is a simplification and standardization of Renovate settings.

Renovate configuration update:

* Switched the `extends` field in `.github/renovate.json5` to use `renovate-config/default.json5` from the shared repository, replacing the previous custom config and manager settings.
* Removed custom `packageRules` that grouped Immich Docker containers and the `customManagers:dockerfileVersions` extension, further simplifying the configuration.