### PR TITLE
feat(uptime-kuma): add uptime-kuma

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -55,3 +55,10 @@ prometheus.stzky.com {
 	encode zstd gzip
 	reverse_proxy :9090
 }
+
+uptime.stzky.com, status.stzky.com, status.ykzts.com, status.ykzts.technology {
+	import secure-headers
+
+	encode zstd gzip
+	reverse_proxy :3001
+}

--- a/uptime-kuma/compose.yaml
+++ b/uptime-kuma/compose.yaml
@@ -1,0 +1,32 @@
+name: uptime-kuma
+
+services:
+  database:
+    container_name: mariadb
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_ROOT_HOST: localhost
+      MYSQL_USER: ${MYSQL_USER}
+    image: mariadb:12.0.2-noble@sha256:03a03a6817bb9eaa21e5aed1b734d432ec3f80021f5a2de1795475f158217545
+    restart: always
+    volumes:
+      - /opt/uptime-kuma/mariadb:/var/lib/mysql
+
+  uptime-kuma:
+    container_name: uptime-kuma
+    depends_on:
+      database:
+        condition: service_started
+    environment:
+      UPTIME_KUMA_DB_HOSTNAME: database
+      UPTIME_KUMA_DB_NAME: ${MYSQL_DATABASE}
+      UPTIME_KUMA_DB_PASSWORD: ${MYSQL_PASSWORD}
+      UPTIME_KUMA_DB_PORT: 3306
+      UPTIME_KUMA_DB_TYPE: mariadb
+      UPTIME_KUMA_DB_USERNAME: ${MYSQL_USER}
+    image: ghcr.io/louislam/uptime-kuma:2.0.0-beta.4@sha256:128685b2fb6e6caa4765220edb4458e107bb2b26af7ba43c320df8e3c3ea8e92
+    ports:
+      - 127.0.0.1:3001:3001
+    restart: always


### PR DESCRIPTION
This pull request introduces the Uptime Kuma monitoring service to the project and configures it for secure and efficient deployment. The main changes include adding a new Docker Compose setup for Uptime Kuma and updating the Caddy configuration to route traffic for multiple status domains to the new service.

**New service deployment:**

* Added `uptime-kuma/compose.yaml` to define the Uptime Kuma service and its MariaDB database, including environment variables, images, and persistent storage.

**Web server configuration:**

* Updated `caddy/config/caddy/Caddyfile` to proxy requests for `uptime.stzky.com`, `status.stzky.com`, `status.ykzts.com`, and `status.ykzts.technology` to the new Uptime Kuma service on port 3001, with secure headers and compression enabled.