### PR TITLE
fix(devcontainer): fix k8s setup and add cert-manager

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,9 @@ FROM mcr.microsoft.com/devcontainers/base:2.1.8-trixie@sha256:e389149057371298ea
 
 RUN apt-get update && apt-get install -y apache2-utils && rm -rf /var/lib/apt/lists/*
 
-# renovate: datasource=github-releases depName=kubectl packageName=kubernetes/kubernetes extractVersion=^v(?<version>.+)$
+# renovate: datasource=github-releases depName=kubectl packageName=kubernetes/kubernetes
 ARG KUBECTL_VERSION=1.36.0
+ENV KUBECTL_VERSION=${KUBECTL_VERSION}
 
 RUN \
   if [ "${KUBECTL_VERSION}" != "none" ]; then \
@@ -14,8 +15,9 @@ RUN \
     && rm kubectl kubectl.sha256; \
   fi
 
-# renovate: datasource=github-releases depNamea=argocd packageName=argoproj/argo-cd
+# renovate: datasource=github-releases depName=argocd packageName=argoproj/argo-cd
 ARG ARGOCD_VERSION=3.3.9
+ENV ARGOCD_VERSION=${ARGOCD_VERSION}
 
 RUN \
   if [ "${ARGOCD_VERSION}" != "none" ]; then \
@@ -26,6 +28,7 @@ RUN \
 
 # renovate: datasource=github-releases depName=helm packageName=helm/helm
 ARG HELM_VERSION=4.1.4
+ENV HELM_VERSION=${HELM_VERSION}
 
 RUN \
   if [ "${HELM_VERSION}" != "none" ]; then \
@@ -35,8 +38,9 @@ RUN \
     && rm -rf helm helm.tar.gz; \
   fi
 
-# renovate: datasource=github-releases depName=yamlfmt packageName=google/yamlfmt extractVersion=^v(?<version>.+)$
+# renovate: datasource=github-releases depName=yamlfmt packageName=google/yamlfmt
 ARG YAMLFMT_VERSION=0.21.0
+ENV YAMLFMT_VERSION=${YAMLFMT_VERSION}
 
 RUN \
   if [ "${YAMLFMT_VERSION}" != "none" ]; then \
@@ -45,3 +49,15 @@ RUN \
     && install yamlfmt /usr/local/bin/yamlfmt \
     && rm -f yamlfmt yamlfmt.tar.gz; \
   fi
+
+# renovate: datasource=github-releases depName=gateway-api packageName=kubernetes-sigs/gateway-api
+ARG GATEWAY_API_VERSION=1.2.1
+ENV GATEWAY_API_VERSION=${GATEWAY_API_VERSION}
+
+# renovate: datasource=helm depName=cilium packageName=cilium/cilium
+ARG CILIUM_VERSION=1.17.3
+ENV CILIUM_VERSION=${CILIUM_VERSION}
+
+# renovate: datasource=helm depName=cert-manager packageName=jetstack/cert-manager
+ARG CERT_MANAGER_VERSION=1.14.4
+ENV CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION}

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -18,11 +18,18 @@ services:
       K3S_KUBECONFIG_MODE: "666"
     image: rancher/k3s:v1.35.4-k3s1@sha256:475e036b3fd595472c13ec708c148ffd95459d5f9e40e6df76ba4d5b27098570
     privileged: true
-    tmpfs:
-      - /run
-      - /var/run
     volumes:
       - k3s-kubeconfig:/k8s
+      - type: bind
+        source: /sys/fs/bpf
+        target: /sys/fs/bpf
+        bind:
+          propagation: shared
+      - type: bind
+        source: /sys/fs/cgroup
+        target: /sys/fs/cgroup
+        bind:
+          propagation: shared
 
 volumes:
   k3s-kubeconfig:

--- a/.devcontainer/setup-k8s.sh
+++ b/.devcontainer/setup-k8s.sh
@@ -3,33 +3,59 @@ set -e
 
 until kubectl get nodes > /dev/null 2>&1; do sleep 1; done
 
-echo "Installing Gateway API CRDs..."
-# renovate: datasource=github-releases depName=gateway-api packageName=kubernetes-sigs/gateway-api extractVersion=^v(?<version>.+)$
-GATEWAY_API_VERSION=1.2.1
-kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v${GATEWAY_API_VERSION}/standard-install.yaml"
+if [ -n "${GATEWAY_API_VERSION}" ] && [ "${GATEWAY_API_VERSION}" != "none" ]; then
+  echo "Installing Gateway API CRDs (v${GATEWAY_API_VERSION})..."
+  kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v${GATEWAY_API_VERSION}/standard-install.yaml"
+else
+  echo "Skipping Gateway API CRDs installation (GATEWAY_API_VERSION is not set or none)."
+fi
 
-echo "Installing Cilium..."
-NODE_IP=$(kubectl get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
-helm repo add cilium https://helm.cilium.io/
-helm repo update cilium
-# renovate: datasource=helm depName=cilium packageName=cilium/cilium
-CILIUM_VERSION=1.17.3
-helm install cilium cilium/cilium \
-  --version "${CILIUM_VERSION}" \
-  --namespace kube-system \
-  --set operator.replicas=1 \
-  --set ipam.mode=kubernetes \
-  --set kubeProxyReplacement=true \
-  --set gatewayAPI.enabled=true \
-  --set k8sServiceHost="${NODE_IP}" \
-  --set k8sServicePort=6443
+if [ -n "${CILIUM_VERSION}" ] && [ "${CILIUM_VERSION}" != "none" ]; then
+  echo "Installing Cilium (v${CILIUM_VERSION})..."
+  echo "Waiting for node InternalIP to be assigned..."
+  until NODE_IP=$(kubectl get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null) && [ -n "${NODE_IP}" ]; do sleep 1; done
+  helm repo add cilium https://helm.cilium.io/
+  helm repo update cilium
+  helm upgrade --install cilium cilium/cilium \
+    --version "${CILIUM_VERSION}" \
+    --namespace kube-system \
+    --set operator.replicas=1 \
+    --set ipam.mode=kubernetes \
+    --set kubeProxyReplacement=true \
+    --set gatewayAPI.enabled=true \
+    --set k8sServiceHost="${NODE_IP}" \
+    --set k8sServicePort=6443 \
+    --set cgroup.autoMount.enabled=false
 
-echo "Waiting for Cilium to be ready..."
-kubectl wait --for=condition=Ready pod -l k8s-app=cilium -n kube-system --timeout=300s
-kubectl wait --for=condition=Ready node --all --timeout=120s
+  echo "Waiting for Cilium to be ready..."
+  kubectl wait --for=condition=Ready pod -l k8s-app=cilium -n kube-system --timeout=300s
+  kubectl wait --for=condition=Ready node --all --timeout=120s
+else
+  echo "Skipping Cilium installation (CILIUM_VERSION is not set or none)."
+fi
 
-echo "Installing ArgoCD..."
-kubectl create namespace argocd
-kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+if [ -n "${CERT_MANAGER_VERSION}" ] && [ "${CERT_MANAGER_VERSION}" != "none" ]; then
+  echo "Installing cert-manager (v${CERT_MANAGER_VERSION})..."
+  helm repo add jetstack https://charts.jetstack.io
+  helm repo update jetstack
+  helm upgrade --install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --version "${CERT_MANAGER_VERSION}" \
+    --set installCRDs=true
 
-kubectl wait --for=condition=Available deployment/argocd-server -n argocd --timeout=300s
+  echo "Waiting for cert-manager to be ready..."
+  kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=cert-manager -n cert-manager --timeout=120s
+else
+  echo "Skipping cert-manager installation (CERT_MANAGER_VERSION is not set or none)."
+fi
+
+if [ -n "${ARGOCD_VERSION}" ] && [ "${ARGOCD_VERSION}" != "none" ]; then
+  echo "Installing ArgoCD (v${ARGOCD_VERSION})..."
+  kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
+  kubectl apply -n argocd --server-side --force-conflicts -f "https://raw.githubusercontent.com/argoproj/argo-cd/v${ARGOCD_VERSION}/manifests/install.yaml"
+
+  kubectl wait --for=condition=Available deployment/argocd-server -n argocd --timeout=300s
+else
+  echo "Skipping ArgoCD installation."
+fi


### PR DESCRIPTION
## Changes

### feat: Add cert-manager to devcontainer k8s setup

- `setup-k8s.sh` に cert-manager のインストール処理を追加
- `Dockerfile` に cert-manager のバージョン管理（ARG/ENV）を追加

### fix: Fix Cilium startup failure in DinD environment

- `compose.yaml` の `/run`・`/var/run` の `tmpfs` を削除
  - `tmpfs` は常に `private` propagation になるため、Cilium の init container 間でマウントが共有されず起動に失敗していた
- `/sys/fs/bpf` と `/sys/fs/cgroup` を `shared` propagation でバインドマウントするよう追加
- Cilium の Helm オプションに `cgroup.autoMount.enabled=false` を追加

### fix: Fix NODE_IP race condition in setup-k8s.sh

- `kubectl get nodes` が応答しても `InternalIP` が未割り当ての場合があり、Cilium インストールが `jsonpath` エラーで失敗していた
- `InternalIP` が割り当てられるまで待機するループを追加

### fix: Make helm installs idempotent

- `helm install` → `helm upgrade --install` に変更（リビルド時の重複インストールエラーを防止）
- `kubectl create namespace argocd` → `--dry-run=client | kubectl apply` に変更

### fix: Fix ArgoCD manifest URL

- `stable` タグから `v${ARGOCD_VERSION}` に変更し、Renovate によるバージョン管理と一致させた

### fix: Export ARG as ENV in Dockerfile

- 全ツールのバージョンを `ARG` だけでなく `ENV` にも設定することで、コンテナ起動後の `setup-k8s.sh` から環境変数として参照可能に
- `setup-k8s.sh` 内のハードコードされたバージョン定義と renovate コメントを削除

### fix: Fix typo in renovate comment

- `depNamea=argocd` → `depName=argocd` のタイポを修正（Renovate が ArgoCD のバージョンを更新できない原因になっていた）