### PR TITLE
fix(caddy): add `MCP_ACCESS_TOKEN` environment variable

### DIFF
--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       - PROMETHEUS_HASHED_PASSWORD=${PROMETHEUS_HASHED_PASSWORD}
       - PROMETHEUS_AUTH_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
+      - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
     image: caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562
     network_mode: host
     ports:


### PR DESCRIPTION
This pull request introduces a small configuration update to the `caddy/compose.yaml` file. The change adds a new environment variable to the Caddy service configuration.

- Configuration update:
  * Added the `MCP_ACCESS_TOKEN` environment variable to the Caddy service, enabling it to access resources or services that require this token.