### PR TITLE
feat(caddy): update authorization header check with regex

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -67,7 +67,7 @@ mcp.stzky.com {
 	import secure-headers
 
 	@unauthorized {
-		not header Authorization "Bearer {$MCP_ACCESS_TOKEN}"
+		not header_regexp auth Authorization `^(?i:Bearer)\s+{$MCP_ACCESS_TOKEN}$`
 	}
 
 	handle @unauthorized {


### PR DESCRIPTION
This pull request updates the authentication logic in the `Caddyfile` to improve header matching for bearer tokens. The main change is a more robust check for the `Authorization` header using a regular expression.

Authentication improvements:

* Updated the `@unauthorized` matcher to use `header_regexp` for the `Authorization` header, allowing for case-insensitive matching of "Bearer" and flexible whitespace handling.