### PR TITLE
feat: add `.devcontainer/devcontainer-lock.json`

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
+      "version": "2.16.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
+      "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a `.devcontainer/devcontainer-lock.json` file to the repository. The new lock file ensures that the development container uses a specific, reproducible version of the `docker-in-docker` feature for consistent development environments.

- Dev container environment:
  * Added `.devcontainer/devcontainer-lock.json` to lock the `docker-in-docker` feature to version `2.16.1`, ensuring reproducible container builds.