### PR TITLE
feat(homepage): add bookmarks

### DIFF
--- a/homepage/config/homepage/bookmarks.yaml
+++ b/homepage/config/homepage/bookmarks.yaml
@@ -1,1 +1,17 @@
 ---
+- Check-in:
+    - Genshin Impact:
+        - abbr: GI
+          href: https://act.hoyolab.com/ys/event/signin-sea-v3/index.html?act_id=e202102251931481
+
+    - 'Honkai: Star Rail':
+        - abbr: SR
+          href: https://act.hoyolab.com/bbs/event/signin/hkrpg/index.html?act_id=e202303301540311
+
+    - Zenless Zone Zero:
+        - abbr: ZZ
+          href: https://act.hoyolab.com/bbs/event/signin/zzz/e202406031448091.html?act_id=e202406031448091
+
+    - "Arknights: Endfield"
+        - abbr: AE
+          href: https://game.skport.com/endfield/sign-in


### PR DESCRIPTION
This pull request adds new check-in bookmark entries for several games to the `homepage/config/homepage/bookmarks.yaml` file. These entries provide quick access to daily sign-in pages for popular games.

New check-in bookmarks:

* Added check-in links for `Genshin Impact`, `Honkai: Star Rail`, `Zenless Zone Zero`, and `Arknights: Endfield`, each with their respective abbreviations and URLs.