### PR TITLE
fix(homepage): fix yaml syntax

### DIFF
--- a/homepage/config/homepage/bookmarks.yaml
+++ b/homepage/config/homepage/bookmarks.yaml
@@ -12,6 +12,6 @@
         - abbr: ZZ
           href: https://act.hoyolab.com/bbs/event/signin/zzz/e202406031448091.html?act_id=e202406031448091
 
-    - "Arknights: Endfield"
+    - 'Arknights: Endfield':
         - abbr: AE
           href: https://game.skport.com/endfield/sign-in


### PR DESCRIPTION
This pull request makes a small formatting correction to the `homepage/config/homepage/bookmarks.yaml` file. The change updates the way "Arknights: Endfield" is represented to use a key-value format, which is more consistent with YAML best practices.