### PR TITLE
feat: shared network

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Create network
+        run: docker create network stzky-ingress
+
       - name: Create .env file for ${{ matrix.service }}
         working-directory: ${{ matrix.service }}
         run: |

--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -3,12 +3,15 @@ services:
     cap_add:
       - NET_ADMIN
     container_name: caddy
+    extra_hosts:
+      - host.docker.internal:host-gateway
     environment:
       - PROMETHEUS_HASHED_PASSWORD=${PROMETHEUS_HASHED_PASSWORD}
       - PROMETHEUS_AUTH_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
       - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
     image: caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562
-    network_mode: host
+    networks:
+      - stzky-ingress
     ports:
       - 443:443
       - 443:443/udp
@@ -23,3 +26,7 @@ services:
 volumes:
   caddy_config:
   caddy_data:
+
+networks:
+  stzky-ingress:
+    external: true

--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -22,14 +22,14 @@ stzky.com {
   import secure-headers
 
   encode zstd gzip
-  reverse_proxy :10000
+  reverse_proxy homepage:10000
 }
 
 console.stzky.com {
 	import secure-headers
 
 	encode zstd gzip
-	reverse_proxy :9000
+	reverse_proxy host.docker.internal:9000
 }
 
 graph.stzky.com {
@@ -38,7 +38,7 @@ graph.stzky.com {
 	encode zstd gzip
 	header {
 	}
-	reverse_proxy :3000
+	reverse_proxy grafana:3000
 }
 
 photos.stzky.com {
@@ -50,7 +50,7 @@ photos.stzky.com {
 		Permissions-Policy "camera=(), display-capture=(), geolocation=(self), microphone=()"
 		-X-Powered-By
 	}
-	reverse_proxy :2283
+	reverse_proxy immich-server:2283
 }
 
 prometheus.stzky.com {
@@ -60,14 +60,14 @@ prometheus.stzky.com {
 		{$PROMETHEUS_AUTH_USERNAME} {$PROMETHEUS_HASHED_PASSWORD}
 	}
 	encode zstd gzip
-	reverse_proxy :9090
+	reverse_proxy prometheus:9090
 }
 
 uptime.stzky.com, status.stzky.com, status.ykzts.com, status.ykzts.technology {
 	import secure-headers
 
 	encode zstd gzip
-	reverse_proxy :3001
+	reverse_proxy uptime-kuma:3001
 }
 
 mcp.stzky.com {
@@ -82,13 +82,13 @@ mcp.stzky.com {
 		respond `{"error": "Unauthorized", "message": "Valid token required"}` 401
 	}
 
-	reverse_proxy :8811
+	reverse_proxy gateway:8811
 }
 
 epub.ykzts.com {
 	encode zstd gzip
 
-	reverse_proxy :8085 {
+	reverse_proxy epub-web:8085 {
 		transport http {
 			versions h2c 2
 		}

--- a/epub-web/compose.yaml
+++ b/epub-web/compose.yaml
@@ -11,6 +11,11 @@ services:
       EPUB_WEB_REQUEST_TIMEOUT: 90s
       EPUB_WEB_SHUTDOWN_TIMEOUT: 15s
     image: ghcr.io/publira/epub-web:1.1.4@sha256:617baa62bdb9b5d66ea45da2a8ec9ea51f363d464c4692803aa598728a18eaec
-    ports:
-      - 127.0.0.1:8085:8080
+    networks:
+      - stzky-ingress
+      - default
     restart: always
+
+networks:
+  stzky-ingress:
+    external: true

--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -9,7 +9,9 @@ services:
       - ALLOY_PROMETHEUS_PASSWORD=${ALLOY_PROMETHEUS_PASSWORD}
       - ALLOY_PROMETHEUS_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
     image: grafana/alloy:v1.16.0@sha256:6e00cf7c5a692ff5f24844529416ed017d76fce922f8199004e73d5eca46b6b8
-    network_mode: host
+    networks:
+      - default
+      - stzky-ingress
     restart: always
     volumes:
       - ./config/alloy:/etc/alloy:ro
@@ -57,8 +59,9 @@ services:
       - GF_SNAPSHOTS_EXTERNAL_ENABLED=false
       - GF_USERS_DEFAULT_THEME=system
     image: grafana/grafana:13.0.1@sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a
-    ports:
-      - 127.0.0.1:3000:3000
+    networks:
+      - default
+      - stzky-ingress
     restart: always
     user: '0'
     volumes:
@@ -88,6 +91,9 @@ services:
       - --web.enable-remote-write-receiver
     container_name: prometheus
     image: prom/prometheus:v3.11.3@sha256:e4254400b85610324913f0dc4acf92603d9984e7519414c5a12811aa6146acc3
+    networks:
+      - default
+      - stzky-ingress
     ports:
       - 127.0.0.1:9090:9090
     volumes:
@@ -107,3 +113,7 @@ services:
     container_name: snmp_exporter
     image: prom/snmp-exporter:v0.30.1@sha256:e5fd5e8b43ace6c088fe9bf0b37b7fff0e04380bee352be7ec41b853a4dd5859
     restart: always
+
+networks:
+  stzky-ingress:
+    external: true

--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -94,8 +94,6 @@ services:
     networks:
       - default
       - stzky-ingress
-    ports:
-      - 127.0.0.1:9090:9090
     volumes:
       - ./config/prometheus:/etc/prometheus:ro
       - /opt/grafana/prometheus:/prometheus

--- a/grafana/config/alloy/config.alloy
+++ b/grafana/config/alloy/config.alloy
@@ -12,7 +12,7 @@ prometheus.scrape "caddy_metrics" {
   job_name        = "caddy"
   scrape_interval = "15s"
   targets         = [
-    {"__address__" = "localhost:2019", group = "infrastructure", service = "caddy"},
+    {"__address__" = "caddy:2019", group = "infrastructure", service = "caddy"},
   ]
 }
 
@@ -21,7 +21,7 @@ prometheus.scrape "immich_api" {
   job_name        = "immich_api"
   scrape_interval = "15s"
   targets         = [
-    {"__address__" = "localhost:8081", group = "immich", service = "immich-api"},
+    {"__address__" = "immich-server:8081", group = "immich", service = "immich-api"},
   ]
 }
 
@@ -30,17 +30,12 @@ prometheus.scrape "immich_microservices" {
   job_name        = "immich_microservices"
   scrape_interval = "15s"
   targets         = [
-    {"__address__" = "localhost:8082", group = "immich", service = "immich-microservices"},
+    {"__address__" = "immich-server:8082", group = "immich", service = "immich-microservices"},
   ]
 }
 
 prometheus.remote_write "default" {
   endpoint {
-    url = "https://prometheus.stzky.com/api/v1/write"
-
-    basic_auth {
-      username = sys.env("ALLOY_PROMETHEUS_USERNAME")
-      password = sys.env("ALLOY_PROMETHEUS_PASSWORD")
-    }
+    url = "http://prometheus:9090/api/v1/write"
   }
 }

--- a/homepage/compose.yaml
+++ b/homepage/compose.yaml
@@ -5,9 +5,14 @@ services:
       HOMEPAGE_ALLOWED_HOSTS: stzky.com
       LOG_TARGETS: stdout
     image: ghcr.io/gethomepage/homepage:v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401
-    ports:
-      - 127.0.0.1:10000:3000
+    networks:
+      - default
+      - stzky-ingress
     restart: always
     volumes:
       - ./config/homepage:/app/config:ro
       - ./public/images:/app/public/images:ro
+
+networks:
+  stzky-ingress:
+    external: true

--- a/immich/compose.yaml
+++ b/immich/compose.yaml
@@ -44,10 +44,9 @@ services:
     healthcheck:
       disable: false
     image: ghcr.io/immich-app/immich-server:v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
-    ports:
-      - 127.0.0.1:2283:2283
-      - 127.0.0.1:8081:8081
-      - 127.0.0.1:8082:8002
+    networks:
+      - default
+      - stzky-ingress
     restart: always
     volumes:
       - ${UPLOAD_LOCATION}:/data
@@ -62,3 +61,7 @@ services:
 
 volumes:
   model-cache:
+
+networks:
+  stzky-ingress:
+    external: true

--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -1,8 +1,9 @@
 services:
   gateway:
     image: docker/mcp-gateway:v0.42.1@sha256:582c83ba9b6032a6f495d0e98e7ff6442eebe89f7c476fa7672ce115911c99c5
-    ports:
-      - "8811:8811"
+    networks:
+      - default
+      - stzky-ingress
     command:
       - --transport=streaming
       - --servers=firecrawl
@@ -124,3 +125,7 @@ services:
 
 volumes:
   firecrawl-nuq-postgres-data:
+
+networks:
+  stzky-ingress:
+    external: true

--- a/uptime-kuma/compose.yaml
+++ b/uptime-kuma/compose.yaml
@@ -27,6 +27,11 @@ services:
       UPTIME_KUMA_DB_TYPE: mariadb
       UPTIME_KUMA_DB_USERNAME: ${MYSQL_USER}
     image: ghcr.io/louislam/uptime-kuma:2.3.2@sha256:9aeb4e51d038047f414309c77a1af553281ca535723cb88907d907269d0a908e
-    ports:
-      - 127.0.0.1:3001:3001
+    networks:
+      - default
+      - stzky-ingress
     restart: always
+
+networks:
+  stzky-ingress:
+    external: true


### PR DESCRIPTION
This pull request updates the networking configuration for multiple services to use a shared external Docker network (`stzky-ingress`) instead of relying on host networking or direct port publishing. This change standardizes service connectivity, improves isolation, and simplifies reverse proxying in Caddy. Service references in the Caddyfile have also been updated to use container names or `host.docker.internal` where appropriate.

**Networking and Docker Compose changes:**

* Added the external `stzky-ingress` network to all major service `compose.yaml` files (`caddy`, `epub-web`, `grafana`, `homepage`, `immich`, `mcp-gateway`, `uptime-kuma`), connecting relevant services to this network and removing direct port mappings or `network_mode: host` where previously used. [[1]](diffhunk://#diff-29c200b0e847395481453be8a6628d360f34050f62c8b52aee4c6e5bfc729c7fR6-R14) [[2]](diffhunk://#diff-29c200b0e847395481453be8a6628d360f34050f62c8b52aee4c6e5bfc729c7fR29-R32) [[3]](diffhunk://#diff-b98798cbd2fdb16090d87f53b6a0349456ac3962547f9c3ed1aaf4f1e8dbb107L14-R21) [[4]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cL12-R14) [[5]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cL60-R64) [[6]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cR94-R96) [[7]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cR116-R119) [[8]](diffhunk://#diff-45741e66b634e6a2b05ed5eb4d5b9c35d6bfe5b9e9a588aa81383724765aafafL8-R18) [[9]](diffhunk://#diff-0b6891c50a853c1a3a57cc7e3281c458833d56300e84f29e66497446d9e7655cL47-R49) [[10]](diffhunk://#diff-0b6891c50a853c1a3a57cc7e3281c458833d56300e84f29e66497446d9e7655cR64-R67) [[11]](diffhunk://#diff-720513475e474ed859dffaa507ebab584bc25f90f95f1a0bfc8fdfe28e90609dL4-R6) [[12]](diffhunk://#diff-720513475e474ed859dffaa507ebab584bc25f90f95f1a0bfc8fdfe28e90609dR128-R131) [[13]](diffhunk://#diff-09ea4e7e74b1dede91d6409ac79c2f5f606e953ffc178ce40299e35e5f52c84dL30-R37)

* Added a workflow step in `.github/workflows/test.yml` to create the `stzky-ingress` network before running tests, ensuring consistency in CI environments.

**Caddy reverse proxy and configuration updates:**

* Updated the `Caddyfile` to use service/container names (e.g., `homepage:10000`, `grafana:3000`, `immich-server:2283`, `prometheus:9090`, `uptime-kuma:3001`, `gateway:8811`, `epub-web:8085`) for reverse proxy targets instead of `localhost` ports. For some services, `host.docker.internal` is used to reach the host network. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L25-R32) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L41-R41) [[3]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L53-R53) [[4]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L63-R70) [[5]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L85-R91)

* Added `extra_hosts` mapping for `host.docker.internal` in the Caddy service to allow Caddy to resolve and proxy to host services when necessary.

These changes improve maintainability, security, and clarity of service interconnections by leveraging Docker networking best practices.