### PR TITLE
fix(caddy): fix homepage port

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -22,7 +22,7 @@ stzky.com {
   import secure-headers
 
   encode zstd gzip
-  reverse_proxy homepage:10000
+  reverse_proxy homepage:3000
 }
 
 console.stzky.com {


### PR DESCRIPTION
This pull request makes a minor configuration change to the `Caddyfile` by updating the reverse proxy target port for the `stzky.com` service.

- Changed the `reverse_proxy` directive for `stzky.com` from forwarding to `homepage:10000` to `homepage:3000`.