### PR TITLE
feat(caddy): redirect from www to naked domain

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -18,10 +18,14 @@
 	}
 }
 
-stzky.com {
+stzky.com, www.stzky.com {
   import secure-headers
 
   encode zstd gzip
+
+  @www host www.stzky.com
+  redir @www https://stzky.com{uri} permanent
+
   reverse_proxy homepage:3000
 }
 


### PR DESCRIPTION
This pull request updates the `Caddyfile` configuration to improve domain handling for `stzky.com`. The main change ensures that requests to `www.stzky.com` are redirected to the apex domain, consolidating traffic and improving SEO.

Domain routing and redirection improvements:

* Updated the `stzky.com` site block to include both `stzky.com` and `www.stzky.com` domains, and added a redirect rule so that all requests to `www.stzky.com` are permanently redirected to `stzky.com` with the same URI.