### PR TITLE
fix(alloy): fix immich monitor port

### DIFF
--- a/grafana/config/alloy/config.alloy
+++ b/grafana/config/alloy/config.alloy
@@ -30,7 +30,7 @@ prometheus.scrape "immich_microservices" {
   job_name        = "immich_microservices"
   scrape_interval = "15s"
   targets         = [
-    {"__address__" = "immich-server:8082", group = "immich", service = "immich-microservices"},
+    {"__address__" = "immich-server:8002", group = "immich", service = "immich-microservices"},
   ]
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the Prometheus scrape configuration for the `immich_microservices` job, correcting the port number for the target service.

- Changed the `__address__` for the `immich_microservices` Prometheus scrape target from port `8082` to `8002` in `grafana/config/alloy/config.alloy` to ensure metrics are collected from the correct endpoint.