### PR TITLE
fead(caddy): use wildcard domain

### DIFF
--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,0 +1,8 @@
+FROM caddy:2.11.2-builder@sha256:1ecefa333507828a592aaecc68d5f62a993787057429c04e9b0438a65c980a30 AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/cloudflare
+
+FROM caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -1,5 +1,6 @@
 services:
   caddy:
+    build: .
     cap_add:
       - NET_ADMIN
     container_name: caddy
@@ -16,7 +17,6 @@ services:
       - 443:443
       - 443:443/udp
       - 80:80
-      - 127.0.0.1:2019:2019
     restart: always
     volumes:
       - caddy_config:/config

--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -18,15 +18,28 @@
 	}
 }
 
-stzky.com, www.stzky.com {
-  import secure-headers
+stzky.com, *.stzky.com {
+	tls {
+		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
+	}
 
-  encode zstd gzip
+	@apex host stzky.com
+	handle @apex {
+		import secure-headers
 
-  @www host www.stzky.com
-  redir @www https://stzky.com{uri} permanent
+		encode zstd gzip
+		reverse_proxy homepage:3000
+	}
 
-  reverse_proxy homepage:3000
+	@www host www.stzky.com
+	handle @www {
+	import secure-headers
+
+	encode zstd gzip
+	redir https://stzky.com{uri} permanent
+	}
+
+	abort
 }
 
 console.stzky.com {
@@ -91,7 +104,6 @@ mcp.stzky.com {
 
 epub.ykzts.com {
 	encode zstd gzip
-
 	reverse_proxy epub-web:8085 {
 		transport http {
 			versions h2c 2


### PR DESCRIPTION
This pull request updates the Caddy reverse proxy setup to enable wildcard domain support, integrate DNS-based certificate management with Cloudflare, and streamline the Docker deployment process. The changes primarily focus on improving flexibility for subdomains, automating TLS certificate provisioning, and simplifying container builds.

**Caddyfile and TLS improvements:**

* Updated the main site block in `Caddyfile` to support `*.stzky.com` (wildcard subdomains) and configured DNS-based TLS certificate management using the Cloudflare plugin and API token environment variable. This allows automatic issuance and renewal of certificates for all subdomains.
* Refactored routing logic for `stzky.com` and `www.stzky.com` to use named request matchers and `handle` blocks, improving clarity and maintainability.

**Docker and deployment enhancements:**

* Added a multi-stage `Dockerfile` to build Caddy with the Cloudflare DNS plugin using `xcaddy`, enabling DNS challenge support for certificate management.
* Updated `compose.yaml` to build the Caddy image locally (using the new `Dockerfile`) instead of pulling a prebuilt image, ensuring the custom plugin is included.
* Removed the `127.0.0.1:2019:2019` port mapping from `compose.yaml`, likely to reduce unnecessary port exposure or simplify the configuration.