### PR TITLE
fix(caddy): remove duplicate image

### DIFF
--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -10,7 +10,6 @@ services:
       - PROMETHEUS_HASHED_PASSWORD=${PROMETHEUS_HASHED_PASSWORD}
       - PROMETHEUS_AUTH_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
       - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
-    image: caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562
     networks:
       - stzky-ingress
     ports:


### PR DESCRIPTION
This pull request makes a minor change to the `caddy/compose.yaml` file by removing the explicit `image` tag for the Caddy service. This will cause Docker Compose to use the default image specified elsewhere or the latest available image, rather than pinning to version `2.11.2`.

- Removed the explicit `image: caddy:2.11.2@sha256:25cdc846626b62d05f6b633b9b40c2c9f6ef89b515dc76133cefd920f7dbe562` line from the Caddy service in `caddy/compose.yaml`