### PR TITLE
fix(caddy): pass env

### DIFF
--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -7,9 +7,10 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
+      - CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN}
+      - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
       - PROMETHEUS_HASHED_PASSWORD=${PROMETHEUS_HASHED_PASSWORD}
       - PROMETHEUS_AUTH_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
-      - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
     networks:
       - stzky-ingress
     ports:


### PR DESCRIPTION
This pull request makes a minor update to the environment variable configuration in the `caddy/compose.yaml` file. The main change is the addition of the `CLOUDFLARE_API_TOKEN` environment variable to the `services` section, ensuring it's available for the service.

- Configuration update:
  * Added `CLOUDFLARE_API_TOKEN` to the environment variables for the service, making it available for integrations that require Cloudflare API access.