### PR TITLE
fix(caddy): update image configuration and clean up Caddyfile

### DIFF
--- a/caddy/compose.yaml
+++ b/caddy/compose.yaml
@@ -11,6 +11,7 @@ services:
       - MCP_ACCESS_TOKEN=${MCP_ACCESS_TOKEN}
       - PROMETHEUS_HASHED_PASSWORD=${PROMETHEUS_HASHED_PASSWORD}
       - PROMETHEUS_AUTH_USERNAME=${ALLOY_PROMETHEUS_USERNAME}
+    image: ghcr.io/ykzts/caddy
     networks:
       - stzky-ingress
     ports:

--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -31,75 +31,94 @@ stzky.com, *.stzky.com {
 		reverse_proxy homepage:3000
 	}
 
+  @console host console.stzky.com
+  handle {
+    import secure-headers
+
+    encode zstd gzip
+    reverse_proxy host.docker.internal:9000
+  }
+
+  @graph host graph.stzky.com
+  handle {
+    import secure-headers
+
+    encode zstd gzip
+    reverse_proxy grafana:3000
+  }
+
+  @photos host photos.stzky.com
+  handle {
+    import secure-headers
+
+    encode zstd gzip
+    header {
+      Content-Security-Policy "base-uri 'self'; connect-src 'self' https://pay.futo.org https://static.immich.cloud https://tiles.immich.cloud; default-src 'none'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; sandbox allow-downloads allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.gstatic.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
+      Permissions-Policy "camera=(), display-capture=(), geolocation=(self), microphone=()"
+      -X-Powered-By
+    }
+    reverse_proxy immich-server:2283
+  }
+
+  @prometheus host prometheus.stzky.com
+  handle @prometheus {
+    import secure-headers
+
+    basic_auth {
+      {$PROMETHEUS_AUTH_USERNAME} {$PROMETHEUS_HASHED_PASSWORD}
+    }
+    encode zstd gzip
+    reverse_proxy prometheus:9090
+  }
+
+  @mcp host mcp.stzky.com
+  handle @mcp {
+    import secure-headers
+
+    @unauthorized {
+      not header_regexp auth Authorization `^(?i:Bearer)\s+{$MCP_ACCESS_TOKEN}$`
+    }
+
+    handle @unauthorized {
+      header Content-Type application/json
+      respond `{"error": "Unauthorized", "message": "Valid token required"}` 401
+    }
+
+    reverse_proxy gateway:8811
+  }
+
+  @uptime host uptime.stzky.com
+  handle @uptime {
+    import secure-headers
+
+    encode zstd gzip
+    reverse_proxy uptime-kuma:3001
+  }
+
+  @status host status.stzky.com
+  handle @status {
+    import secure-headers
+
+    encode zstd gzip
+    reverse_proxy uptime-kuma:3001
+  }
+
 	@www host www.stzky.com
 	handle @www {
-	import secure-headers
+    import secure-headers
 
-	encode zstd gzip
-	redir https://stzky.com{uri} permanent
+    encode zstd gzip
+    redir https://stzky.com{uri} permanent
 	}
 
 	abort
 }
 
-console.stzky.com {
-	import secure-headers
-
-	encode zstd gzip
-	reverse_proxy host.docker.internal:9000
-}
-
-graph.stzky.com {
-	import secure-headers
-
-	encode zstd gzip
-	header {
-	}
-	reverse_proxy grafana:3000
-}
-
-photos.stzky.com {
-	import secure-headers
-
-	encode zstd gzip
-	header {
-		Content-Security-Policy "base-uri 'self'; connect-src 'self' https://pay.futo.org https://static.immich.cloud https://tiles.immich.cloud; default-src 'none'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; sandbox allow-downloads allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.gstatic.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
-		Permissions-Policy "camera=(), display-capture=(), geolocation=(self), microphone=()"
-		-X-Powered-By
-	}
-	reverse_proxy immich-server:2283
-}
-
-prometheus.stzky.com {
-	import secure-headers
-
-	basic_auth {
-		{$PROMETHEUS_AUTH_USERNAME} {$PROMETHEUS_HASHED_PASSWORD}
-	}
-	encode zstd gzip
-	reverse_proxy prometheus:9090
-}
-
-uptime.stzky.com, status.stzky.com, status.ykzts.com, status.ykzts.technology {
+status.ykzts.com, status.ykzts.technology {
 	import secure-headers
 
 	encode zstd gzip
 	reverse_proxy uptime-kuma:3001
-}
-
-mcp.stzky.com {
-	import secure-headers
-
-	@unauthorized {
-		not header_regexp auth Authorization `^(?i:Bearer)\s+{$MCP_ACCESS_TOKEN}$`
-	}
-
-	handle @unauthorized {
-		header Content-Type application/json
-		respond `{"error": "Unauthorized", "message": "Valid token required"}` 401
-	}
-
-	reverse_proxy gateway:8811
 }
 
 epub.ykzts.com {


### PR DESCRIPTION
This pull request refactors the Caddy server configuration to improve maintainability and consistency by switching to named matchers and handlers for subdomains, and makes a minor update to the Caddy service image in the Docker Compose file. The main changes include reorganizing the `Caddyfile` to use named matchers for each subdomain, moving and consolidating some domain configurations, and updating the `caddy` image source.

**Caddyfile refactoring and domain handling:**

* Switched from block-based subdomain configuration to using named matchers (`@subdomain`) and `handle` directives for each subdomain (such as `console.stzky.com`, `graph.stzky.com`, `photos.stzky.com`, `prometheus.stzky.com`, `mcp.stzky.com`, `uptime.stzky.com`, and `status.stzky.com`), improving clarity and maintainability. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L34-R51) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L73-R64) [[3]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L83-R75) [[4]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194R90-R123)
* Relocated the `www.stzky.com` redirect logic to the end of the main block, now using a named matcher and handler for consistency with other subdomains. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L34-R51) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194R90-R123)
* Split out `status.ykzts.com` and `status.ykzts.technology` into their own block, separating them from the other status/uptime domains for clearer configuration.

**Docker Compose update:**

* Updated the Caddy service in `caddy/compose.yaml` to use the `ghcr.io/ykzts/caddy` image, which may provide customizations or updates over the previous image.