### PR TITLE
fix(caddy): update handle directives for console, graph, and photos

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -32,7 +32,7 @@ stzky.com, *.stzky.com {
 	}
 
 	@console host console.stzky.com
-	handle {
+	handle @console {
 		import secure-headers
 
 		encode zstd gzip
@@ -40,7 +40,7 @@ stzky.com, *.stzky.com {
 	}
 
 	@graph host graph.stzky.com
-	handle {
+	handle @graph {
 		import secure-headers
 
 		encode zstd gzip
@@ -48,7 +48,7 @@ stzky.com, *.stzky.com {
 	}
 
 	@photos host photos.stzky.com
-	handle {
+	handle @photo {
 		import secure-headers
 
 		encode zstd gzip


### PR DESCRIPTION
This pull request updates the `Caddyfile` to improve routing specificity by ensuring that each subdomain handler only applies to its intended host. The main change is switching from generic `handle` blocks to targeted `handle` blocks that use the appropriate host matchers.

Routing improvements:

* Updated the `handle` blocks for `console.stzky.com`, `graph.stzky.com`, and `photos.stzky.com` to use `handle @console`, `handle @graph`, and `handle @photo` respectively, ensuring that each handler only matches requests for its specific subdomain.