### PR TITLE
fix(caddy): fix typo in handle directive for photos

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -48,7 +48,7 @@ stzky.com, *.stzky.com {
 	}
 
 	@photos host photos.stzky.com
-	handle @photo {
+	handle @photos {
 		import secure-headers
 
 		encode zstd gzip


### PR DESCRIPTION
This pull request corrects a minor typo in the `Caddyfile` configuration by updating a handle block to use the correct matcher name, ensuring that the `photos.stzky.com` host is handled as intended.

- Configuration fix:
  * Changed the handle block from `@photo` to `@photos` in the `Caddyfile` to match the defined matcher and ensure proper routing for `photos.stzky.com`.