### PR TITLE
feat(caddy): add json logging configuration to Caddyfile

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -23,6 +23,11 @@ stzky.com, *.stzky.com {
 		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
 	}
 
+	log {
+		output stdout
+		format json
+	}
+
 	@apex host stzky.com
 	handle @apex {
 		import secure-headers
@@ -115,6 +120,11 @@ stzky.com, *.stzky.com {
 }
 
 status.ykzts.com, status.ykzts.technology {
+	log {
+		output stdout
+		format json
+	}
+
 	import secure-headers
 
 	encode zstd gzip
@@ -122,6 +132,11 @@ status.ykzts.com, status.ykzts.technology {
 }
 
 epub.ykzts.com {
+	log {
+		output stdout
+		format json
+	}
+
 	encode zstd gzip
 	reverse_proxy epub-web:8080 {
 		transport http {


### PR DESCRIPTION
This pull request adds structured logging to the Caddy server configuration for several domains. The main update is the introduction of JSON-formatted logs output to stdout, which will improve log management and integration with external monitoring tools.

Logging enhancements:

* Added a `log` block to the `stzky.com, *.stzky.com`, `status.ykzts.com, status.ykzts.technology`, and `epub.ykzts.com` site definitions in the `Caddyfile` to output logs in JSON format to stdout. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194R26-R30) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194R123-R139)