### PR TITLE
fix(grafana): add missing config

### DIFF
--- a/grafana/config/loki/local-config.yaml
+++ b/grafana/config/loki/local-config.yaml
@@ -28,4 +28,6 @@ limits_config:
   retention_period: 720h
 
 compactor:
+  working_directory: /loki/compactor
   retention_enabled: true
+  delete_request_store: filesystem


### PR DESCRIPTION
This pull request updates the Loki compactor configuration to specify a working directory and change the delete request store to use the filesystem.

Configuration updates:

* Set `compactor.working_directory` to `/loki/compactor` to define where compactor operations will take place.
* Set `compactor.delete_request_store` to `filesystem` to store delete requests on the filesystem instead of the default.