### PR TITLE
fix(loki): add relabeling rules for docker logs

### DIFF
--- a/grafana/config/alloy/config.alloy
+++ b/grafana/config/alloy/config.alloy
@@ -44,10 +44,25 @@ discovery.docker "containers" {
   host = "unix:///var/run/docker.sock"
 }
 
+loki.relabel "docker_logs" {
+  forward_to = [loki.write.local_loki.receiver]
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container_name"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service_name"
+  }
+}
+
 loki.source.docker "local_logs" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.docker.containers.targets
-  forward_to = [loki.write.local_loki.receiver]
+  forward_to = [loki.relabel.docker_logs.receiver]
 }
 
 loki.write "local_loki" {


### PR DESCRIPTION
This pull request updates the Docker log processing pipeline in the `grafana/config/alloy/config.alloy` file to improve log labeling and organization. The main change is the introduction of a new relabeling stage for Docker logs, which adds more descriptive labels to log entries before they are written to Loki.

**Log processing improvements:**

* Added a new `loki.relabel "docker_logs"` block to apply relabeling rules to Docker log entries, extracting the container name and service name as labels.
* Updated the `loki.source.docker "local_logs"` block to forward logs to the new relabeling stage instead of directly to the Loki write receiver.