### PR TITLE
feat(grafana): disable gzip

### DIFF
--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -63,6 +63,7 @@ services:
       - GF_SECURITY_CONTENT_SECURITY_POLICY=true
       - GF_SERVER_DOMAIN=graph.stzky.com
       - GF_SERVER_ROOT_URL=https://graph.stzky.com
+      - GF_SERVER_ENABLE_GZIP=false
       - GF_SMTP_ENABLED=true
       - GF_SMTP_FROM_ADDRESS=${GF_SMTP_FROM_ADDRESS}
       - GF_SMTP_FROM_NAME=${GF_SMTP_FROM_NAME}


### PR DESCRIPTION
This pull request makes a minor configuration change to the Grafana service by explicitly disabling GZIP compression.

- Configuration update:
  * Set the environment variable `GF_SERVER_ENABLE_GZIP` to `false` in `grafana/compose.yaml`, which disables GZIP compression for the Grafana server.