### PR TITLE
refactor(caddy): reorganize logging and secure-headers imports

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -36,22 +36,24 @@
 	}
 }
 
+(json-log) {
+	log {
+		output stdout
+		format json
+	}
+}
+
 stzky.com, *.stzky.com {
 	tls {
 		dns cloudflare {env.CLOUDFLARE_API_TOKEN}
 	}
 
-	log {
-		output stdout
-		format json
-	}
-
+	import secure-headers
 	import custom-errors
+	import json-log
 
 	@apex host stzky.com
 	handle @apex {
-		import secure-headers
-
 		encode zstd gzip
 		reverse_proxy homepage:3000 {
 			@404 status 404
@@ -63,24 +65,18 @@ stzky.com, *.stzky.com {
 
 	@console host console.stzky.com
 	handle @console {
-		import secure-headers
-
 		encode zstd gzip
 		reverse_proxy host.docker.internal:9000
 	}
 
 	@graph host graph.stzky.com
 	handle @graph {
-		import secure-headers
-
 		encode zstd gzip
 		reverse_proxy grafana:3000
 	}
 
 	@photos host photos.stzky.com
 	handle @photos {
-		import secure-headers
-
 		encode zstd gzip
 		header {
 			Content-Security-Policy "base-uri 'self'; connect-src 'self' https://pay.futo.org https://static.immich.cloud https://tiles.immich.cloud; default-src 'none'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self'; sandbox allow-downloads allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.gstatic.com; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
@@ -92,8 +88,6 @@ stzky.com, *.stzky.com {
 
 	@prometheus host prometheus.stzky.com
 	handle @prometheus {
-		import secure-headers
-
 		basic_auth {
 			{$PROMETHEUS_AUTH_USERNAME} {$PROMETHEUS_HASHED_PASSWORD}
 		}
@@ -103,8 +97,6 @@ stzky.com, *.stzky.com {
 
 	@mcp host mcp.stzky.com
 	handle @mcp {
-		import secure-headers
-
 		@unauthorized {
 			not header_regexp auth Authorization `^(?i:Bearer)\s+{$MCP_ACCESS_TOKEN}$`
 		}
@@ -119,24 +111,18 @@ stzky.com, *.stzky.com {
 
 	@uptime host uptime.stzky.com
 	handle @uptime {
-		import secure-headers
-
 		encode zstd gzip
 		reverse_proxy uptime-kuma:3001
 	}
 
 	@status host status.stzky.com
 	handle @status {
-		import secure-headers
-
 		encode zstd gzip
 		reverse_proxy uptime-kuma:3001
 	}
 
 	@www host www.stzky.com
 	handle @www {
-		import secure-headers
-
 		encode zstd gzip
 		redir https://stzky.com{uri} permanent
 	}
@@ -147,22 +133,15 @@ stzky.com, *.stzky.com {
 }
 
 status.ykzts.com, status.ykzts.technology {
-	log {
-		output stdout
-		format json
-	}
-
 	import secure-headers
+	import json-log
 
 	encode zstd gzip
 	reverse_proxy uptime-kuma:3001
 }
 
 epub.ykzts.com {
-	log {
-		output stdout
-		format json
-	}
+	import json-log
 
 	encode zstd gzip
 	reverse_proxy epub-web:8080 {


### PR DESCRIPTION
This pull request refactors the Caddy server configuration to improve maintainability and consistency by introducing a reusable log configuration snippet and streamlining the import of security headers. The main changes involve defining a `(json-log)` snippet for JSON logging and applying it across relevant server blocks, while also removing redundant `import secure-headers` statements from individual handlers.

**Logging and configuration improvements:**

* Added a reusable `(json-log)` snippet to configure JSON logging, and imported this snippet into all relevant server blocks to ensure consistent log formatting. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L39-L54) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L150-R144)
* Removed repeated `log` blocks in `status.ykzts.com`, `status.ykzts.technology`, and `epub.ykzts.com`, replacing them with the new `json-log` snippet for cleaner configuration.

**Security and maintainability improvements:**

* Moved the `import secure-headers` directive to the top level of the `stzky.com, *.stzky.com` block, eliminating redundant imports from individual handlers and ensuring secure headers are consistently applied. [[1]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L39-L54) [[2]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L66-L83) [[3]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L95-L96) [[4]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L106-L107) [[5]](diffhunk://#diff-29d3d78d1a68541a4a02703dcb21869e81f735d6d65db1a52d116868065b7194L122-L139)

These changes make the Caddyfile easier to maintain and ensure consistent application of logging and security settings across all sites.