### PR TITLE
feat(baserow): add stzky-ingress network to compose.yaml

### DIFF
--- a/baserow/compose.yaml
+++ b/baserow/compose.yaml
@@ -38,6 +38,7 @@ services:
     image: baserow/backend:2.2.2
     networks:
       - local
+      - stzky-ingress
     restart: always
 
   web-frontend:
@@ -51,6 +52,7 @@ services:
     image: baserow/web-frontend:2.2.2
     networks:
       - local
+      - stzky-ingress
     restart: always
 
   celery:
@@ -131,3 +133,5 @@ volumes:
 networks:
   local:
     driver: bridge
+  stzky-ingress:
+    external: true


### PR DESCRIPTION
This pull request updates the Docker Compose configuration for Baserow to improve network connectivity. The main change is the addition of the external `stzky-ingress` network to both the backend and web-frontend services, allowing them to communicate with resources on that network.

**Network configuration updates:**

* Added the external `stzky-ingress` network to the `backend` service in `baserow/compose.yaml` to enable connectivity with external services.
* Added the external `stzky-ingress` network to the `web-frontend` service in `baserow/compose.yaml` for similar connectivity purposes.
* Defined the `stzky-ingress` network as an external network in the `networks` section of `baserow/compose.yaml`.