### PR TITLE
fix(caddy): change handle directive from @console to @base

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -64,7 +64,7 @@ stzky.com, *.stzky.com {
 	}
 
 	@base host base.stzky.com
-	handle @console {
+	handle @base {
 		encode zstd gzip
 
 		@backend_routes path /api/* /ws/* /mcp/* /assistant/*


### PR DESCRIPTION
This pull request makes a small but important fix to the `Caddyfile` by correcting the handle directive to use the correct matcher. This ensures that the routing logic applies to the intended host.

- Changed the `handle` directive from `@console` to `@base` to correctly match requests for `base.stzky.com` and apply the appropriate encoding and backend routing.