### PR TITLE
fix(open-webui): change model

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -1,7 +1,7 @@
 services:
   ovms:
     command: >
-      --source_model OpenVINO/gemma-2-2b-it-int4-ov
+      --source_model OpenVINO/gemma-3-4b-it-int4-cw-ov
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request updates the model used by the `ovms` service in the `open-webui/compose.yaml` file. The service now uses a newer or different model as its source.

Model update:

* Changed the `--source_model` argument for the `ovms` service from `OpenVINO/gemma-2-2b-it-int4-ov` to `OpenVINO/gemma-3-4b-it-int4-cw-ov` to use a newer or different model.