### PR TITLE
fix(caddy): fix open-webui port

### DIFF
--- a/caddy/config/caddy/Caddyfile
+++ b/caddy/config/caddy/Caddyfile
@@ -78,7 +78,7 @@ stzky.com, *.stzky.com {
 	@chat host chat.stzky.com
 	handle @chat {
 		encode zstd gzip
-		reverse_proxy open-webui:3000
+		reverse_proxy open-webui:8080
 	}
 
 	@console host console.stzky.com


### PR DESCRIPTION
This pull request makes a small configuration update to the `Caddyfile` for the `chat.stzky.com` subdomain. The change updates the backend port for the reverse proxy.

- Changed the `reverse_proxy` target for `chat.stzky.com` from port `3000` to port `8080` to route traffic to the correct backend service.