### PR TITLE
fix(open-webui): set model name

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -2,6 +2,7 @@ services:
   ovms:
     command: >
       --source_model OpenVINO/gemma-3-4b-it-int4-cw-ov
+      --model_name gemma3
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request makes a minor update to the `ovms` service configuration in `open-webui/compose.yaml` by specifying a model name for clarity and explicitness.

* Service configuration update:
  * Added the `--model_name gemma3` argument to the `ovms` service command to explicitly set the model name.