### PR TITLE
feat(open-webui): set shm_size for ovms

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -16,6 +16,7 @@ services:
       - "993"
     image: openvino/model_server:2026.1-gpu@sha256:22f92a1a5ad6784384e47296c43bde239887a623e75de45b0e1802659de416a6
     restart: always
+    shm_size: 16gb
     volumes:
       - ovms-models:/models
 


### PR DESCRIPTION
This pull request makes a small configuration change to the `open-webui/compose.yaml` file. The change increases the shared memory size allocated to the OpenVINO Model Server container, which can help prevent memory issues when running large models.

* Increased the `shm_size` for the OpenVINO Model Server container to `16gb` in `open-webui/compose.yaml`.