### PR TITLE
fix(baserow): fix healthcheck command syntax in compose.yaml

### DIFF
--- a/baserow/compose.yaml
+++ b/baserow/compose.yaml
@@ -110,7 +110,7 @@ services:
     healthcheck:
       interval: 10s
       retries: 10
-      test: su postgres -c "pg_isready -U "$$POSTGRES_USER"
+      test: su postgres -c "pg_isready -U $$POSTGRES_USER"
     image: pgvector/pgvector:0.8.2-pg18-trixie@sha256:b7337db8fe39d12fe8ecb0003c72680f24479813a744b43154eee6f2eab5a5f3
     networks:
       - local


### PR DESCRIPTION
This pull request makes a minor fix to the `baserow/compose.yaml` file by correcting the syntax in the `healthcheck` command for the Postgres service. The change removes unnecessary escaping of the `POSTGRES_USER` variable to ensure it is correctly interpreted.

- Fixed the `healthcheck` command in the Postgres service to properly reference the `POSTGRES_USER` environment variable without extra escaping.