### PR TITLE
fix(open-webui): fix model name

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -2,7 +2,7 @@ services:
   ovms:
     command: >
       --source_model OpenVINO/gemma-3-12b-it-int8-ov
-      --model_name Gemma 3
+      --model_name "Gemma 3"
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request makes a minor update to the `open-webui/compose.yaml` file by quoting the value for the `--model_name` argument in the `ovms` service command to ensure proper parsing.

- Quoted the `--model_name` value as `"Gemma 3"` in the `ovms` service command to prevent issues with spaces in the model name.