### PR TITLE
fix(open-webui): change model name

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -2,7 +2,7 @@ services:
   ovms:
     command: >
       --source_model OpenVINO/gemma-3-12b-it-int8-ov
-      --model_name "Gemma 3"
+      --model_name gemma-3-12b
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request makes a minor update to the `open-webui/compose.yaml` file, specifically changing the model name used for the OVMS service to ensure consistency with naming conventions.

- Changed the `--model_name` parameter in the OVMS service from `"Gemma 3"` to `gemma-3-12b` for improved consistency and clarity.