### PR TITLE
fix(open-webui): change model

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -1,8 +1,8 @@
 services:
   ovms:
     command: >
-      --source_model OpenVINO/gemma-3-12b-it-int8-ov
-      --model_name gemma-3-12b
+      --source_model OpenVINO/gemma-3-4b-it-int8-ov
+      --model_name gemma-3-4b
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request updates the `ovms` service configuration in `compose.yaml` to use a different model variant. The model has been changed from `gemma-3-12b` to `gemma-3-4b`, reflecting a shift to a smaller model for text generation tasks.

Model configuration update:

* Changed the `--source_model` and `--model_name` parameters for the `ovms` service from `gemma-3-12b-it-int8-ov`/`gemma-3-12b` to `gemma-3-4b-it-int8-ov`/`gemma-3-4b` in `open-webui/compose.yaml`.