### PR TITLE
feat(grafana): introduce cadvisor

### DIFF
--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -20,14 +20,20 @@ services:
       - alloy_data:/var/lib/alloy
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
-  loki:
-    command: -config.file=/etc/loki/local-config.yaml
-    container_name: loki
-    image: grafana/loki:3.7.2@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
+  cadvisor:
+    container_name: cadvisor
+    detach: true
+    devices:
+      - /dev/kmsg:/dev/kmsg:
+    image: ghcr.io/google/cadvisor:0.57.0@sha256:e75bdb03b74b0b6995f208f166fead2e6e555dde73e44200113bb26f41b1981d
+    privileged: true
     restart: always
     volumes:
-      - ./config/loki:/etc/loki:ro
-      - loki_data:/loki
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
 
   database:
     container_name: grafana_postgres
@@ -80,6 +86,15 @@ services:
     user: '0'
     volumes:
       - /opt/grafana/grafana:/var/lib/grafana
+
+  loki:
+    command: -config.file=/etc/loki/local-config.yaml
+    container_name: loki
+    image: grafana/loki:3.7.2@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
+    restart: always
+    volumes:
+      - ./config/loki:/etc/loki:ro
+      - loki_data:/loki
 
   node-exporter:
     command:

--- a/grafana/config/prometheus/prometheus.yml
+++ b/grafana/config/prometheus/prometheus.yml
@@ -3,6 +3,10 @@ global:
 
 scrape_configs:
   - static_configs:
+      - targets: ['cadvisor:8080']
+    job_name: cadvisor
+
+  - static_configs:
       - targets: ['grafana:3000']
     job_name: grafana
 


### PR DESCRIPTION
This pull request updates the monitoring stack by introducing cAdvisor for container metrics collection and ensuring Prometheus is configured to scrape its metrics. It also reorganizes the `loki` service definition for better structure in the `docker-compose` file.

**Monitoring stack enhancements:**

* Added a `cadvisor` service to `grafana/compose.yaml` for container metrics collection, including necessary volume and device mappings for host access.
* Updated `grafana/config/prometheus/prometheus.yml` to add a Prometheus scrape configuration for the new `cadvisor` service, enabling Prometheus to collect container metrics.

**Compose file reorganization:**

* Moved the `loki` service definition lower in `grafana/compose.yaml` to improve logical grouping and readability of services. No changes to the actual `loki` configuration. [[1]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cL23-R36) [[2]](diffhunk://#diff-65363012bb7bfe8db3739fbbf6527fa6a1a7a0fe5cb6dbb2c1303f11d530fc2cR90-R98)