### PR TITLE
fix(grafana): remove unnecessary `:`

### DIFF
--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -24,7 +24,7 @@ services:
     container_name: cadvisor
     detach: true
     devices:
-      - /dev/kmsg:/dev/kmsg:
+      - /dev/kmsg:/dev/kmsg
     image: ghcr.io/google/cadvisor:0.57.0@sha256:e75bdb03b74b0b6995f208f166fead2e6e555dde73e44200113bb26f41b1981d
     privileged: true
     restart: always


### PR DESCRIPTION
This pull request includes a minor syntax correction in the `grafana/compose.yaml` file, specifically in the device mapping for the `cadvisor` service. The trailing colon was removed from the `/dev/kmsg:/dev/kmsg` device mapping to correct the format.