### PR TITLE
fix(grafana): remove `detach` property

### DIFF
--- a/grafana/compose.yaml
+++ b/grafana/compose.yaml
@@ -22,7 +22,6 @@ services:
 
   cadvisor:
     container_name: cadvisor
-    detach: true
     devices:
       - /dev/kmsg:/dev/kmsg
     image: ghcr.io/google/cadvisor:0.57.0@sha256:e75bdb03b74b0b6995f208f166fead2e6e555dde73e44200113bb26f41b1981d


### PR DESCRIPTION
Removed detach option from cadvisor service in compose file.