### PR TITLE
feat(compose): add container names for services in compose.yaml

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -1,5 +1,6 @@
 services:
   gateway:
+    container_name: mcp-gateway
     image: docker/mcp-gateway:v0.42.1@sha256:582c83ba9b6032a6f495d0e98e7ff6442eebe89f7c476fa7672ce115911c99c5
     networks:
       - default
@@ -13,6 +14,7 @@ services:
       - mcp-firecrawl
 
   mcp-firecrawl:
+    container_name: mcp-firecrawl
     image: mcp/firecrawl@sha256:bd3d3a3a71a7803b61255447072db65835fe82558749ac2297a33806da3a327e
     entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "node", "dist/index.js"]
     environment:
@@ -37,6 +39,7 @@ services:
         target: /docker-mcp
 
   firecrawl:
+    container_name: firecrawl
     image: ghcr.io/firecrawl/firecrawl:latest@sha256:4bdf6d61c4f0690b3c9f8fe10600b773145cc6df45b3abef65697b634de19fa3
     command: ["node", "dist/src/harness.js", "--start-docker"]
     environment:
@@ -70,6 +73,7 @@ services:
       - no-new-privileges
 
   firecrawl-playwright:
+    container_name: firecrawl-playwright
     image: ghcr.io/firecrawl/playwright-service:latest@sha256:443030bed5c8162c85998276f76bf7f8a95545dfeb088581f41f91506cfa1017
     environment:
       - PORT=3000
@@ -80,6 +84,7 @@ services:
       - no-new-privileges
 
   firecrawl-redis:
+    container_name: firecrawl-redis
     image: redis:8.6-alpine@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2
     command: ["redis-server", "--bind", "0.0.0.0"]
     init: true
@@ -89,6 +94,7 @@ services:
       - no-new-privileges
 
   firecrawl-rabbitmq:
+    container_name: firecrawl-rabbitmq
     image: rabbitmq:4.3-management-alpine@sha256:1a43764bdcf116542e7c8c794adc67c79461727da16d474e9e21483fe7f716d3
     init: true
     healthcheck:
@@ -103,6 +109,7 @@ services:
       - no-new-privileges
 
   firecrawl-postgres:
+    container_name: firecrawl-postgres
     image: ghcr.io/firecrawl/nuq-postgres:latest@sha256:f9388bd25ae2e1f1d034518236f993ce236173c1d8800ce24092ea6643a95a33
     command: ["postgres", "-c", "cron.database_name=firecrawl"]
     environment:


### PR DESCRIPTION
This pull request updates the `mcp-gateway/compose.yaml` file to explicitly set container names for all services defined in the Docker Compose configuration. This change improves clarity and makes it easier to reference and manage containers during development and debugging.

**Container naming improvements:**

* Added `container_name` fields for the following services to ensure consistent and explicit container names:
  - `gateway` (`mcp-gateway`)
  - `mcp-firecrawl` (`mcp-firecrawl`)
  - `firecrawl` (`firecrawl`)
  - `firecrawl-playwright` (`firecrawl-playwright`)
  - `firecrawl-redis` (`firecrawl-redis`)
  - `firecrawl-rabbitmq` (`firecrawl-rabbitmq`)
  - `firecrawl-postgres` (`firecrawl-postgres`)