### PR TITLE
feat(firecrawl): add firecrawl services configuration in compose.yaml

### DIFF
--- a/firecrawl/compoase.yaml
+++ b/firecrawl/compoase.yaml
@@ -1,0 +1,102 @@
+services:
+  firecrawl:
+    container_name: firecrawl
+    image: ghcr.io/firecrawl/firecrawl:latest@sha256:4bdf6d61c4f0690b3c9f8fe10600b773145cc6df45b3abef65697b634de19fa3
+    command: ["node", "dist/src/harness.js", "--start-docker"]
+    environment:
+      - HOST=0.0.0.0
+      - PORT=3002
+      - USE_DB_AUTHENTICATION=false
+      - REDIS_URL=redis://firecrawl-redis:6379
+      - REDIS_RATE_LIMIT_URL=redis://firecrawl-redis:6379
+      - PLAYWRIGHT_MICROSERVICE_URL=http://firecrawl-playwright:3000/scrape
+      - NUQ_RABBITMQ_URL=amqp://firecrawl-rabbitmq:5672
+      - POSTGRES_HOST=firecrawl-postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=${FIRECRAWL_POSTGRES_USER:-firecrawl}
+      - POSTGRES_PASSWORD=${FIRECRAWL_POSTGRES_PASSWORD:-firecrawl_password}
+      - POSTGRES_DB=${FIRECRAWL_POSTGRES_DB:-firecrawl}
+      - BULL_AUTH_KEY=${FIRECRAWL_BULL_AUTH_KEY:-CHANGEME}
+    depends_on:
+      firecrawl-redis:
+        condition: service_started
+      firecrawl-rabbitmq:
+        condition: service_healthy
+      firecrawl-playwright:
+        condition: service_started
+      firecrawl-postgres:
+        condition: service_healthy
+    networks:
+      - default
+      - stzky-ingress
+    restart: unless-stopped
+    init: true
+    cpus: 2
+    mem_limit: 4g
+    security_opt:
+      - no-new-privileges
+
+  firecrawl-playwright:
+    container_name: firecrawl-playwright
+    image: ghcr.io/firecrawl/playwright-service:latest@sha256:443030bed5c8162c85998276f76bf7f8a95545dfeb088581f41f91506cfa1017
+    environment:
+      - PORT=3000
+    init: true
+    cpus: 1
+    mem_limit: 2g
+    security_opt:
+      - no-new-privileges
+
+  firecrawl-redis:
+    container_name: firecrawl-redis
+    image: redis:8.6-alpine@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2
+    command: ["redis-server", "--bind", "0.0.0.0"]
+    init: true
+    cpus: 1
+    mem_limit: 1g
+    security_opt:
+      - no-new-privileges
+
+  firecrawl-rabbitmq:
+    container_name: firecrawl-rabbitmq
+    image: rabbitmq:4.3-management-alpine@sha256:1a43764bdcf116542e7c8c794adc67c79461727da16d474e9e21483fe7f716d3
+    init: true
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    cpus: 1
+    mem_limit: 1g
+    security_opt:
+      - no-new-privileges
+
+  firecrawl-postgres:
+    container_name: firecrawl-postgres
+    image: ghcr.io/firecrawl/nuq-postgres:latest@sha256:f9388bd25ae2e1f1d034518236f993ce236173c1d8800ce24092ea6643a95a33
+    command: ["postgres", "-c", "cron.database_name=firecrawl"]
+    environment:
+      - POSTGRES_USER=${FIRECRAWL_POSTGRES_USER:-firecrawl}
+      - POSTGRES_PASSWORD=${FIRECRAWL_POSTGRES_PASSWORD:-firecrawl_password}
+      - POSTGRES_DB=${FIRECRAWL_POSTGRES_DB:-firecrawl}
+    volumes:
+      - firecrawl-nuq-postgres-data:/var/lib/postgresql/data
+    init: true
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${FIRECRAWL_POSTGRES_USER:-firecrawl} -d ${FIRECRAWL_POSTGRES_DB:-firecrawl}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    cpus: 1
+    mem_limit: 2g
+    security_opt:
+      - no-new-privileges
+
+volumes:
+  firecrawl-nuq-postgres-data:
+
+networks:
+  stzky-ingress:
+    external: true

--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -23,6 +23,9 @@ services:
     depends_on:
       firecrawl:
         condition: service_started
+    networks:
+      - default
+      - stzky-ingress
     init: true
     cpus: 1
     mem_limit: 2g
@@ -37,101 +40,6 @@ services:
       - type: image
         source: docker/mcp-gateway
         target: /docker-mcp
-
-  firecrawl:
-    container_name: firecrawl
-    image: ghcr.io/firecrawl/firecrawl:latest@sha256:4bdf6d61c4f0690b3c9f8fe10600b773145cc6df45b3abef65697b634de19fa3
-    command: ["node", "dist/src/harness.js", "--start-docker"]
-    environment:
-      - HOST=0.0.0.0
-      - PORT=3002
-      - USE_DB_AUTHENTICATION=false
-      - REDIS_URL=redis://firecrawl-redis:6379
-      - REDIS_RATE_LIMIT_URL=redis://firecrawl-redis:6379
-      - PLAYWRIGHT_MICROSERVICE_URL=http://firecrawl-playwright:3000/scrape
-      - NUQ_RABBITMQ_URL=amqp://firecrawl-rabbitmq:5672
-      - POSTGRES_HOST=firecrawl-postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_USER=${FIRECRAWL_POSTGRES_USER:-firecrawl}
-      - POSTGRES_PASSWORD=${FIRECRAWL_POSTGRES_PASSWORD:-firecrawl_password}
-      - POSTGRES_DB=${FIRECRAWL_POSTGRES_DB:-firecrawl}
-      - BULL_AUTH_KEY=${FIRECRAWL_BULL_AUTH_KEY:-CHANGEME}
-    depends_on:
-      firecrawl-redis:
-        condition: service_started
-      firecrawl-rabbitmq:
-        condition: service_healthy
-      firecrawl-playwright:
-        condition: service_started
-      firecrawl-postgres:
-        condition: service_healthy
-    restart: unless-stopped
-    init: true
-    cpus: 2
-    mem_limit: 4g
-    security_opt:
-      - no-new-privileges
-
-  firecrawl-playwright:
-    container_name: firecrawl-playwright
-    image: ghcr.io/firecrawl/playwright-service:latest@sha256:443030bed5c8162c85998276f76bf7f8a95545dfeb088581f41f91506cfa1017
-    environment:
-      - PORT=3000
-    init: true
-    cpus: 1
-    mem_limit: 2g
-    security_opt:
-      - no-new-privileges
-
-  firecrawl-redis:
-    container_name: firecrawl-redis
-    image: redis:8.6-alpine@sha256:d146f83b1e0f02fc27c26a50cee39338c736674c5959db84363e6ae3cd9e02d2
-    command: ["redis-server", "--bind", "0.0.0.0"]
-    init: true
-    cpus: 1
-    mem_limit: 1g
-    security_opt:
-      - no-new-privileges
-
-  firecrawl-rabbitmq:
-    container_name: firecrawl-rabbitmq
-    image: rabbitmq:4.3-management-alpine@sha256:1a43764bdcf116542e7c8c794adc67c79461727da16d474e9e21483fe7f716d3
-    init: true
-    healthcheck:
-      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    cpus: 1
-    mem_limit: 1g
-    security_opt:
-      - no-new-privileges
-
-  firecrawl-postgres:
-    container_name: firecrawl-postgres
-    image: ghcr.io/firecrawl/nuq-postgres:latest@sha256:f9388bd25ae2e1f1d034518236f993ce236173c1d8800ce24092ea6643a95a33
-    command: ["postgres", "-c", "cron.database_name=firecrawl"]
-    environment:
-      - POSTGRES_USER=${FIRECRAWL_POSTGRES_USER:-firecrawl}
-      - POSTGRES_PASSWORD=${FIRECRAWL_POSTGRES_PASSWORD:-firecrawl_password}
-      - POSTGRES_DB=${FIRECRAWL_POSTGRES_DB:-firecrawl}
-    volumes:
-      - firecrawl-nuq-postgres-data:/var/lib/postgresql/data
-    init: true
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${FIRECRAWL_POSTGRES_USER:-firecrawl} -d ${FIRECRAWL_POSTGRES_DB:-firecrawl}"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
-    cpus: 1
-    mem_limit: 2g
-    security_opt:
-      - no-new-privileges
-
-volumes:
-  firecrawl-nuq-postgres-data:
 
 networks:
   stzky-ingress:


### PR DESCRIPTION
This pull request refactors the deployment configuration for the Firecrawl services by moving their Docker Compose definitions from `mcp-gateway/compose.yaml` into a new standalone file, `firecrawl/compoase.yaml`. This change improves modularity and separation of concerns, making it easier to manage and maintain the Firecrawl stack independently from the main gateway services. Additionally, the network configuration for the Firecrawl service in the gateway is updated to ensure proper connectivity.

Key changes:

**Firecrawl service configuration modularization:**
* All Firecrawl-related service definitions (`firecrawl`, `firecrawl-playwright`, `firecrawl-redis`, `firecrawl-rabbitmq`, `firecrawl-postgres`) and their associated volumes and networks are removed from `mcp-gateway/compose.yaml` and added to a new dedicated file, `firecrawl/compoase.yaml`. This includes all environment variables, health checks, resource limits, and dependencies. [[1]](diffhunk://#diff-d5e957677185668c0e043298cc16ab20894214eaca616d6dbe727513d6f56f1eR1-R102) [[2]](diffhunk://#diff-720513475e474ed859dffaa507ebab584bc25f90f95f1a0bfc8fdfe28e90609dL41-L135)

**Networking updates:**
* The `firecrawl` service in `mcp-gateway/compose.yaml` is updated to explicitly join both the `default` and `stzky-ingress` networks, ensuring continued communication with other services after the refactor.

These changes make the Firecrawl stack easier to manage independently and clarify the separation between gateway and Firecrawl infrastructure.