### PR TITLE
feat(mcp-gateway): introduce mcp-grafana

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -12,10 +12,12 @@ services:
       - --static=true
     depends_on:
       - mcp-firecrawl
+      - mcp-grafana
+    restart: always
 
   mcp-firecrawl:
     container_name: mcp-firecrawl
-    image: mcp/firecrawl@sha256:bd3d3a3a71a7803b61255447072db65835fe82558749ac2297a33806da3a327e
+    image: mcp/firecrawl:latest@sha256:bd3d3a3a71a7803b61255447072db65835fe82558749ac2297a33806da3a327e
     entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "node", "dist/index.js"]
     environment:
       - FIRECRAWL_API_URL=${FIRECRAWL_API_URL:-http://firecrawl:3002}
@@ -37,6 +39,33 @@ services:
       - type: image
         source: docker/mcp-gateway
         target: /docker-mcp
+    restart: always
+
+  mcp-grafana:
+    container_name: mcp-grafana
+    image: mcp/grafana:latest@sha256:55abb94eb96ccf1c5bfbe400ddce3327751e47c7e74fc53388c4a9d96aa7b1a5
+    entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "uvx", "mcp-grafana"]
+    environment:
+      - GRAFANA_API_URL=${GRAFANA_API_URL:-http://grafana:3000}
+      - GRAFANA_SERVICE_ACCOUNT_TOKEN=${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}
+    networks:
+      - default
+      - stzky-ingress
+    init: true
+    cpus: 1
+    mem_limit: 2g
+    security_opt:
+      - no-new-privileges
+    labels:
+      - docker-mcp=true
+      - docker-mcp-tool-type=mcp
+      - docker-mcp-name=grafana
+      - docker-mcp-transport=stdio
+    volumes:
+      - type: image
+        source: docker/mcp-gateway
+        target: /docker-mcp
+    restart: always
 
 networks:
   stzky-ingress:


### PR DESCRIPTION
This pull request updates the `mcp-gateway/compose.yaml` file to add support for a new `mcp-grafana` service and make some improvements to service configuration. The changes ensure that the new Grafana service is integrated into the Docker Compose setup and improve the reliability of existing services.

**New service integration:**

* Added a new `mcp-grafana` service, including its image, entrypoint, environment variables, resource limits, security options, networks, labels, and volume mounts. This service is now part of the default and `stzky-ingress` networks and is configured with best practices for security and resource usage.

**Service reliability improvements:**

* Added the `restart: always` policy to both the `mcp-gateway` and `mcp-grafana` services to ensure they automatically restart on failure. [[1]](diffhunk://#diff-720513475e474ed859dffaa507ebab584bc25f90f95f1a0bfc8fdfe28e90609dR15-R20) [[2]](diffhunk://#diff-720513475e474ed859dffaa507ebab584bc25f90f95f1a0bfc8fdfe28e90609dR42-R68)
* Updated the `mcp-firecrawl` image reference to use the `latest` tag for improved clarity and maintainability.
* Added `mcp-grafana` as a dependency for the `mcp-gateway` service, ensuring proper startup order.