### PR TITLE
feat(mcp-gateway): update servers list in compose.yaml

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -7,7 +7,7 @@ services:
       - stzky-ingress
     command:
       - --transport=streaming
-      - --servers=firecrawl
+      - --servers=firecrawl,grafana
       - --port=8811
       - --static=true
     depends_on:


### PR DESCRIPTION
This pull request makes a small configuration update to the `mcp-gateway/compose.yaml` file, adding `grafana` to the list of servers in the service command. This change enables the service to connect to both `firecrawl` and `grafana` servers.