### PR TITLE
fix(mcp-gateway): update entrypoint command for mcp-grafana service

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -44,7 +44,7 @@ services:
   mcp-grafana:
     container_name: mcp-grafana
     image: mcp/grafana:latest@sha256:55abb94eb96ccf1c5bfbe400ddce3327751e47c7e74fc53388c4a9d96aa7b1a5
-    entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "uvx", "mcp-grafana"]
+    entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "./mcp-grafana"]
     environment:
       - GRAFANA_API_URL=${GRAFANA_API_URL:-http://grafana:3000}
       - GRAFANA_SERVICE_ACCOUNT_TOKEN=${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}


### PR DESCRIPTION
This pull request makes a small update to the `mcp-gateway/compose.yaml` file, specifically adjusting the entrypoint command for the `mcp-grafana` service. The change replaces the `uvx` argument with `./mcp-grafana` in the entrypoint array.