### PR TITLE
fix(mcp-gateway): add ports mapping and update transport type for mcp-grafana service

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -14,8 +14,6 @@ services:
       - mcp-firecrawl
       - mcp-grafana
     restart: always
-    ports:
-      - 8811:8811
 
   mcp-firecrawl:
     container_name: mcp-firecrawl

--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -14,6 +14,8 @@ services:
       - mcp-firecrawl
       - mcp-grafana
     restart: always
+    ports:
+      - 8811:8811
 
   mcp-firecrawl:
     container_name: mcp-firecrawl
@@ -60,7 +62,7 @@ services:
       - docker-mcp=true
       - docker-mcp-tool-type=mcp
       - docker-mcp-name=grafana
-      - docker-mcp-transport=stdio
+      - docker-mcp-transport=sse
     volumes:
       - type: image
         source: docker/mcp-gateway


### PR DESCRIPTION
This pull request makes two configuration updates to the `mcp-gateway/compose.yaml` file. The first change exposes a new port for the `mcp-gateway` service, and the second updates the transport mechanism for the `mcp-grafana` service.

Configuration changes:

* Exposed port `8811` for the `mcp-gateway` service by adding a `ports` section, allowing external access to this port.
* Changed the `docker-mcp-transport` environment variable for the `mcp-grafana` service from `stdio` to `sse`, switching the communication protocol to Server-Sent Events.