### PR TITLE
fix(mcp-gateway): update entrypoint transport type for mcp-grafana service

### DIFF
--- a/mcp-gateway/compose.yaml
+++ b/mcp-gateway/compose.yaml
@@ -44,7 +44,7 @@ services:
   mcp-grafana:
     container_name: mcp-grafana
     image: mcp/grafana:latest@sha256:55abb94eb96ccf1c5bfbe400ddce3327751e47c7e74fc53388c4a9d96aa7b1a5
-    entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "/app/mcp-grafana", "--transport", "sse", "--address"]
+    entrypoint: ["/docker-mcp/misc/docker-mcp-bridge", "/app/mcp-grafana", "--transport", "stdio"]
     environment:
       - GRAFANA_API_URL=${GRAFANA_API_URL:-http://grafana:3000}
       - GRAFANA_SERVICE_ACCOUNT_TOKEN=${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}
@@ -60,7 +60,7 @@ services:
       - docker-mcp=true
       - docker-mcp-tool-type=mcp
       - docker-mcp-name=grafana
-      - docker-mcp-transport=sse
+      - docker-mcp-transport=stdio
     volumes:
       - type: image
         source: docker/mcp-gateway


### PR DESCRIPTION
This pull request updates the configuration for the `mcp-grafana` service in the `mcp-gateway/compose.yaml` file to change its communication transport method from Server-Sent Events (SSE) to standard input/output (stdio). This affects both the container's entrypoint and its environment variables.

Configuration changes for transport method:

* Changed the `entrypoint` for the `mcp-grafana` service to use `--transport stdio` instead of `--transport sse`.
* Updated the `docker-mcp-transport` environment variable from `sse` to `stdio` for the `mcp-grafana` service.