### PR TITLE
feat(open-webui): set `--max_num_batched_tokens`

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -7,6 +7,7 @@ services:
       --task text_generation
       --target_device GPU
       --rest_port 8000
+      --max_num_batched_tokens 32768
     container_name: ovms
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This pull request makes a minor update to the `open-webui/compose.yaml` file, increasing the maximum number of batched tokens for the text generation service to improve throughput on the GPU.

- Increased the `--max_num_batched_tokens` parameter to `32768` for the text generation service, which may allow for larger or more efficient batch processing.