### PR TITLE
feat(open-webui): add `--cache_size 8`

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -8,6 +8,7 @@ services:
       --target_device GPU
       --rest_port 8000
       --max_num_batched_tokens 32768
+      --cache_size 8
     container_name: ovms
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This pull request introduces a small configuration update to the `open-webui/compose.yaml` file. The change adds a `--cache_size 8` argument to the OVMS service configuration to control the cache size for the service.