### PR TITLE
feat(open-webui): change target device from GPU to CPU in ovms service

### DIFF
--- a/open-webui/compose.yaml
+++ b/open-webui/compose.yaml
@@ -5,7 +5,7 @@ services:
       --model_name gemma-3-4b
       --model_repository_path /models
       --task text_generation
-      --target_device GPU
+      --target_device CPU
       --rest_port 8000
       --max_num_batched_tokens 32768
       --cache_size 8


### PR DESCRIPTION
This pull request makes a small change to the deployment configuration by switching the target device for model inference from GPU to CPU in the `open-webui/compose.yaml` file. This will cause the service to use CPU resources instead of GPU for text generation tasks.