### PR TITLE
fix(n8n): fix invalid env name

### DIFF
--- a/n8n/compose.yaml
+++ b/n8n/compose.yaml
@@ -1,26 +1,26 @@
 services:
   n8n:
     container_name: n8n
-    image: docker.n8n.io/n8nio/n8n:2.21.7
-    restart: always
     depends_on:
       n8n-db:
         condition: service_healthy
+    image: docker.n8n.io/n8nio/n8n:2.21.7
     environment:
+      DB_POSTGRESDB_HOST: n8n-db
+      DB_POSTGRESDB_DATABASE: ${POSTGRES_DB:-n8n}
+      DB_POSTGRESDB_PASSWORD: ${POSTGRES_PASSWORD:-n8n}
+      DB_POSTGRESDB_PORT: '5432'
+      DB_POSTGRESDB_USER: ${POSTGRES_USER:-n8n}
+      DB_TYPE: postgresdb
       GENERIC_TIMEZONE:
       N8N_HOST: flow.stzky.com
       N8N_PROTOCOL: https
-      DB_POSTGRES_HOST: n8n-db
-      DB_POSTGRES_DATABASE: ${POSTGRES_DB:-n8n}
-      DB_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-n8n}
-      DB_POSTGRES_PORT: '5432'
-      DB_POSTGRES_USER: ${POSTGRES_USER:-n8n}
-      DB_TYPE: postgresdb
-    volumes:
-      - n8n_data:/home/node/.n8n
     networks:
       - default
       - stzky-ingress
+    restart: always
+    volumes:
+      - n8n_data:/home/node/.n8n
 
   n8n-db:
     container_name: n8n_postgres


### PR DESCRIPTION
This pull request updates the `n8n/compose.yaml` file to standardize and clarify the environment variable names for the n8n service's PostgreSQL database configuration. The changes also reorder some configuration keys for better readability but do not affect the actual service behavior.

**Environment variable updates:**

* Replaced all `DB_POSTGRES_*` environment variables with `DB_POSTGRESDB_*` equivalents for database configuration, aligning with n8n's recommended naming conventions.

**Configuration reordering and cleanup:**

* Moved the `restart` and `volumes` keys to follow the `environment` section, improving the logical grouping of configuration options.