### PR TITLE
feat(n8n): set base url

### DIFF
--- a/n8n/compose.yaml
+++ b/n8n/compose.yaml
@@ -13,8 +13,11 @@ services:
       DB_POSTGRESDB_USER: ${POSTGRES_USER:-n8n}
       DB_TYPE: postgresdb
       GENERIC_TIMEZONE: Asia/Tokyo
+      N8N_EDITOR_BASE_URL: https://flow.stzky.com
       N8N_HOST: flow.stzky.com
       N8N_PROTOCOL: https
+      VUE_APP_URL_BASE_API: https://flow.stzky.com
+      WEBHOOK_URL: https://flow.stzky.com
     networks:
       - default
       - stzky-ingress


### PR DESCRIPTION
This pull request updates the `n8n/compose.yaml` configuration to support deployment behind a custom domain and to correctly set external URLs for the n8n editor and API. The main changes involve setting new environment variables to ensure the application uses the correct URLs in a production environment.

Configuration updates for deployment:

* Added `N8N_EDITOR_BASE_URL`, `VUE_APP_URL_BASE_API`, and `WEBHOOK_URL` environment variables to point to `https://flow.stzky.com` for correct URL resolution in the n8n editor and API.