### PR TITLE
feat(n8n): setup smtp

### DIFF
--- a/n8n/compose.yaml
+++ b/n8n/compose.yaml
@@ -14,8 +14,15 @@ services:
       DB_TYPE: postgresdb
       GENERIC_TIMEZONE: Asia/Tokyo
       N8N_EDITOR_BASE_URL: https://flow.stzky.com
+      N8N_EMAIL_MODE: smtp
       N8N_HOST: flow.stzky.com
       N8N_PROTOCOL: https
+      N8N_SMTP_HOST: ${N8N_SMTP_HOST:-}
+      N8N_SMTP_PASS: ${N8N_SMTP_PASS:-}
+      N8N_SMTP_PORT: ${N8N_SMTP_PORT:-}
+      N8N_SMTP_SENDER: ${N8N_SMTP_SENDER:-}
+      N8N_SMTP_STARTTLS: 'true'
+      N8N_SMTP_USER: ${N8N_SMTP_USER:-}
       VUE_APP_URL_BASE_API: https://flow.stzky.com
       WEBHOOK_URL: https://flow.stzky.com
     networks:


### PR DESCRIPTION
This pull request updates the `n8n/compose.yaml` configuration to enable SMTP email support for the n8n service. The main changes are the addition of environment variables required for SMTP setup.

**SMTP email configuration:**

* Added `N8N_EMAIL_MODE` set to `smtp` to enable SMTP email sending.
* Introduced environment variables for SMTP configuration: `N8N_SMTP_HOST`, `N8N_SMTP_PORT`, `N8N_SMTP_USER`, `N8N_SMTP_PASS`, `N8N_SMTP_SENDER`, and `N8N_SMTP_STARTTLS`, allowing customization via environment or `.env` file.