### PR TITLE
fix(n8n): disable ssl for smtp

### DIFF
--- a/n8n/compose.yaml
+++ b/n8n/compose.yaml
@@ -21,6 +21,7 @@ services:
       N8N_SMTP_PASS: ${N8N_SMTP_PASS:-}
       N8N_SMTP_PORT: ${N8N_SMTP_PORT:-}
       N8N_SMTP_SENDER: ${N8N_SMTP_SENDER:-}
+      N8N_SMTP_SSL: 'false'
       N8N_SMTP_STARTTLS: 'true'
       N8N_SMTP_USER: ${N8N_SMTP_USER:-}
       VUE_APP_URL_BASE_API: https://flow.stzky.com


### PR DESCRIPTION
This pull request makes a minor configuration update to the `n8n/compose.yaml` file, specifically related to SMTP settings. The change explicitly sets the `N8N_SMTP_SSL` environment variable to `'false'`, clarifying the SMTP connection configuration.

- Configuration update:
  * Explicitly sets `N8N_SMTP_SSL` to `'false'` in the SMTP environment variables for the n8n service in `compose.yaml`, ensuring SSL is not used for SMTP connections.