### PR TITLE
feat(terraform): introduce terraform

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,6 +9,11 @@
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/terraform:1.4.3": {
+      "version": "1.4.3",
+      "resolved": "ghcr.io/devcontainers/features/terraform@sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7",
+      "integrity": "sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/terraform:1.4.3": {
+      "version": "latest"
     }
   },
   "name": "stzky infra",

--- a/infra/terraform/cloudflare/.gitignore
+++ b/infra/terraform/cloudflare/.gitignore
@@ -1,0 +1,8 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+tfplan
+*.tfplan
+*.auto.tfvars
+*.auto.tfvars.json

--- a/infra/terraform/cloudflare/live/prod/account/.terraform.lock.hcl
+++ b/infra/terraform/cloudflare/live/prod/account/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Xf1PHfUfK690caJYZvoudKKBppfleJ6RcqsEQWqKVCw=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/terraform/cloudflare/live/prod/account/backend.hcl
+++ b/infra/terraform/cloudflare/live/prod/account/backend.hcl
@@ -1,0 +1,12 @@
+# Cloudflare R2 backend for Terraform state
+
+bucket = "stzky-tfstate"
+key    = "cloudflare/prod/account/terraform.tfstate"
+region = "auto"
+
+skip_credentials_validation     = true
+skip_region_validation          = true
+skip_requesting_account_id      = true
+use_path_style                  = true
+use_lockfile                    = true
+

--- a/infra/terraform/cloudflare/live/prod/account/main.tf
+++ b/infra/terraform/cloudflare/live/prod/account/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  backend "s3" {}
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {}

--- a/infra/terraform/cloudflare/live/prod/account/r2.tf
+++ b/infra/terraform/cloudflare/live/prod/account/r2.tf
@@ -1,0 +1,24 @@
+
+# R2バケット: baserow-media
+resource "cloudflare_r2_bucket" "baserow_media" {
+  account_id    = var.cloudflare_account_id
+  name          = "baserow-media"
+  jurisdiction  = "default"
+  storage_class = "Standard"
+}
+
+resource "cloudflare_r2_bucket_cors" "baserow_media" {
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.baserow_media.name
+  rules = [{
+    allowed = {
+      headers = ["*"]
+      methods = ["GET", "HEAD"]
+      origins = ["https://base-media.stzky.com"]
+    }
+    expose_headers  = ["ETag", "cf-cache-status"]
+    id              = "baserow-media-public-read"
+    max_age_seconds = 3600
+  }]
+}
+

--- a/infra/terraform/cloudflare/live/prod/account/terraform.tfvars.example
+++ b/infra/terraform/cloudflare/live/prod/account/terraform.tfvars.example
@@ -1,0 +1,1 @@
+cloudflare_account_id = ""

--- a/infra/terraform/cloudflare/live/prod/account/variables.tf
+++ b/infra/terraform/cloudflare/live/prod/account/variables.tf
@@ -1,0 +1,6 @@
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/.terraform.lock.hcl
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.19.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Xf1PHfUfK690caJYZvoudKKBppfleJ6RcqsEQWqKVCw=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/backend.hcl
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/backend.hcl
@@ -1,0 +1,11 @@
+# Cloudflare R2 backend for Terraform state
+
+bucket = "stzky-tfstate"
+key    = "cloudflare/prod/zones/stzky.com/terraform.tfstate"
+region = "auto"
+
+skip_credentials_validation     = true
+skip_region_validation          = true
+skip_requesting_account_id      = true
+use_path_style                  = true
+use_lockfile                    = true

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/dns.tf
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/dns.tf
@@ -1,0 +1,181 @@
+resource "cloudflare_dns_record" "a_wildcard_root_ipv4" {
+  zone_id = var.zone_id
+  name    = "*.stzky.com"
+  type    = "A"
+  ttl     = 1
+  proxied = false
+  content = var.root_endpoint.root_ipv4
+}
+
+resource "cloudflare_dns_record" "a_root_ipv4" {
+  zone_id = var.zone_id
+  name    = "stzky.com"
+  type    = "A"
+  ttl     = 1
+  proxied = false
+  content = var.root_endpoint.root_ipv4
+}
+
+resource "cloudflare_dns_record" "a_uptime_ipv4" {
+  zone_id = var.zone_id
+  name    = "uptime.stzky.com"
+  type    = "A"
+  ttl     = 1
+  proxied = true
+  content = var.uptime_fly_endpoint.ipv4
+}
+
+resource "cloudflare_dns_record" "aaaa_wildcard_root_ipv6" {
+  zone_id = var.zone_id
+  name    = "*.stzky.com"
+  type    = "AAAA"
+  ttl     = 1
+  proxied = false
+  content = var.root_endpoint.root_ipv6
+}
+
+resource "cloudflare_dns_record" "aaaa_root_ipv6" {
+  zone_id = var.zone_id
+  name    = "stzky.com"
+  type    = "AAAA"
+  ttl     = 1
+  proxied = false
+  content = var.root_endpoint.root_ipv6
+}
+
+resource "cloudflare_dns_record" "aaaa_uptime_ipv6" {
+  zone_id = var.zone_id
+  name    = "uptime.stzky.com"
+  type    = "AAAA"
+  ttl     = 1
+  proxied = true
+  content = var.uptime_fly_endpoint.ipv6
+}
+
+
+resource "cloudflare_dns_record" "caa_root_issue_letsencrypt" {
+  zone_id = var.zone_id
+  name    = "stzky.com"
+  type    = "CAA"
+  ttl     = 1
+  proxied = false
+  data = {
+    flags = 0
+    tag   = "issue"
+    value = "letsencrypt.org"
+  }
+}
+
+resource "cloudflare_dns_record" "cname_base_media_public_r2_dev" {
+  zone_id = var.zone_id
+  name    = "base-media.stzky.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  content = "public.r2.dev"
+  # settings = { flatten_cname = false } # flatten_cnameは必要に応じて有効化
+}
+
+resource "cloudflare_dns_record" "cname_status_to_uptime" {
+  zone_id = var.zone_id
+  name    = "status.stzky.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  content = "uptime.stzky.com"
+  # settings = { flatten_cname = false }
+}
+
+resource "cloudflare_dns_record" "https_wildcard_alpn_h3_h2" {
+  zone_id = var.zone_id
+  name    = "*.stzky.com"
+  type    = "HTTPS"
+  ttl     = 1
+  proxied = false
+  data = {
+    priority = 1
+    target   = "."
+    value    = "alpn=\"h3,h2\""
+  }
+}
+
+resource "cloudflare_dns_record" "https_root_alpn_h3_h2" {
+  zone_id = var.zone_id
+  name    = "stzky.com"
+  type    = "HTTPS"
+  ttl     = 1
+  proxied = false
+  data = {
+    priority = 1
+    target   = "."
+    value    = "alpn=\"h3,h2\""
+  }
+}
+
+resource "cloudflare_dns_record" "https_uptime_alpn_h2" {
+  zone_id = var.zone_id
+  name    = "uptime.stzky.com"
+  type    = "HTTPS"
+  ttl     = 1
+  proxied = false
+  data = {
+    priority = 1
+    target   = "."
+    value    = "alpn=\"h2\""
+  }
+}
+
+resource "cloudflare_dns_record" "mx_send_aws_ses" {
+  zone_id  = var.zone_id
+  name     = "send.stzky.com"
+  type     = "MX"
+  ttl      = 60
+  proxied  = false
+  content  = "feedback-smtp.ap-northeast-1.amazonses.com"
+  priority = 10
+}
+
+resource "cloudflare_dns_record" "txt_dmarc_root" {
+  zone_id = var.zone_id
+  name    = "_dmarc.stzky.com"
+  type    = "TXT"
+  ttl     = 1
+  proxied = false
+  content = "v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; rua=mailto:4499c9d737bc4f739ee6a43df904efd3@dmarc-reports.cloudflare.net;"
+}
+
+resource "cloudflare_dns_record" "txt_domainkey_wildcard" {
+  zone_id = var.zone_id
+  name    = "*._domainkey.stzky.com"
+  type    = "TXT"
+  ttl     = 1
+  proxied = false
+  content = "v=DKIM1; p="
+}
+
+resource "cloudflare_dns_record" "txt_domainkey_resend" {
+  zone_id = var.zone_id
+  name    = "resend._domainkey.stzky.com"
+  type    = "TXT"
+  ttl     = 1
+  proxied = false
+  content = "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+hv6/hQi8N+4G/4fUFkH+ImEae6MmQFOu4hvqq886gpLFtGEfJrCzfeT2q0a157bgZ+I+e0K6fNnX8VlJ/cWE0EWdEIhZnms/3qHo090ebMCrg2AkpZmT6JpHAQVMom7WazwR+lqCERlzQGxRQNJ6tY4EHiYqUt4zoBsigMlltwIDAQAB"
+}
+
+resource "cloudflare_dns_record" "txt_spf_send" {
+  zone_id = var.zone_id
+  name    = "send.stzky.com"
+  type    = "TXT"
+  ttl     = 60
+  proxied = false
+  content = "v=spf1 include:amazonses.com ~all"
+}
+
+resource "cloudflare_dns_record" "txt_spf_root_reject" {
+  zone_id = var.zone_id
+  name    = "stzky.com"
+  type    = "TXT"
+  ttl     = 1
+  proxied = false
+  content = "v=spf1 -all"
+}

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/main.tf
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  backend "s3" {}
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {}

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/outputs.tf
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_id" {
+  description = "Zone ID used by this stack"
+  value       = var.zone_id
+}

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/terraform.tfvars.example
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/terraform.tfvars.example
@@ -1,0 +1,11 @@
+zone_id = ""
+
+root_endpoint = {
+	root_ipv4 = "203.0.113.198"
+	root_ipv6 = "2d74:221d:18:b318:ffa:7fbb:5e14:49ad"
+}
+
+uptime_fly_endpoint = {
+	ipv4 = "66.241.124.77"
+	ipv6 = "2a09:8280:1::119:f813:0"
+}

--- a/infra/terraform/cloudflare/live/prod/zones/stzky.com/variables.tf
+++ b/infra/terraform/cloudflare/live/prod/zones/stzky.com/variables.tf
@@ -1,0 +1,21 @@
+
+variable "zone_id" {
+  description = "Cloudflare zone ID"
+  type        = string
+}
+
+variable "root_endpoint" {
+  description = "Apex and wildcard endpoint values for stzky.com"
+  type = object({
+    root_ipv4 = string
+    root_ipv6 = string
+  })
+}
+
+variable "uptime_fly_endpoint" {
+  description = "fly.io endpoint values for uptime.stzky.com"
+  type = object({
+    ipv4 = string
+    ipv6 = string
+  })
+}

--- a/scripts/deploy-cloudflare.sh
+++ b/scripts/deploy-cloudflare.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# 対象ディレクトリ（account/zones両対応）
+STACK_DIR=${1:-infra/terraform/cloudflare/live/prod/account}
+BACKEND_CONFIG="backend.hcl"
+
+# Terraform初期化・plan・apply
+terraform -chdir="$STACK_DIR" init -backend-config="$BACKEND_CONFIG"
+terraform -chdir="$STACK_DIR" plan -out=tfplan
+terraform -chdir="$STACK_DIR" apply tfplan


### PR DESCRIPTION
This pull request introduces a new Terraform-based infrastructure-as-code setup for managing Cloudflare resources. It adds a modular structure for provisioning Cloudflare R2 buckets (including CORS, custom domains, and object lock), and DNS records for the `stzky.com` zone. The changes also include configuration files, documentation, and devcontainer updates to support Terraform workflows.

**Cloudflare Terraform Infrastructure**

*Account-level R2 bucket management:*
- Adds a reusable Terraform module (`modules/account-r2`) to provision Cloudflare R2 buckets, with support for CORS, custom domains, and object lock rules. This is used by the new `live/prod/account` stack to manage `baserow-media` and `stzky-tfstate` buckets. [[1]](diffhunk://#diff-eb5e8233dcd0bb935c49127c5dd1c2c513485e7a24fe0eef331115854fbef7c4R1-R69) [[2]](diffhunk://#diff-0256342e443df7c071b4e39a3af1a99a34f87bc68a398c2842f7dad97932c890R1-R45) [[3]](diffhunk://#diff-858f0c49cd52c20105fb70e4f6a07c7410c0b6693b0ca83a9f9b169b8cf6e066R1-R9)
- Configures the Terraform backend to store state in a Cloudflare R2 bucket for the account stack, including lockfile support. [[1]](diffhunk://#diff-597358641f6793abca00d108e9e250c55c4f33e18a8dbe149edfb592fac82d9aR1-R12) [[2]](diffhunk://#diff-8d4dce2f38c261dabd422d798f89a867bf12158f25c69af00739226f91bcc0a4R1-R14)

*DNS and zone management:*
- Adds a `live/prod/zones/stzky.com` stack to manage DNS records for the `stzky.com` domain, using a dedicated module for DNS records and parameterized variables for endpoints. [[1]](diffhunk://#diff-078ae612e06a95d63d9060982fa1c598e1585e64b02dae6bec35183180cb2e00R1-R190) [[2]](diffhunk://#diff-e2814334d551e4a8337856e938c3d7f4df2bdbb2627dea62d044aa30c34ab8caR1-R12) [[3]](diffhunk://#diff-76d8776e3622b7370143f12877af9e75984e85befdd4a87a2f594d92b6ef8e86R1-R21) [[4]](diffhunk://#diff-a86ebbbfb2ef7bcace82b09beac927e8430d3fdc5eaeff1e3ee69ff4ed8980c5R1-R4) [[5]](diffhunk://#diff-265d68ce1eaf6a451a0401725ddcf17402b94acacf81197f988a7af04734b194R1-R11)
- Configures the Terraform backend for the zone stack to use Cloudflare R2 for state storage.

*Project structure and workflow:*
- Documents the directory structure, recommended workflow, and best practices for secrets and environment configuration in `README.md`.
- Adds `.gitignore` rules to avoid committing Terraform state, plans, and sensitive files.
- Provides example `terraform.tfvars.example` files for both stacks to guide variable configuration. [[1]](diffhunk://#diff-c5de99f879c41c5c69d7225312ac20155d28afd49e24ec8cc1987442e6e44085R1) [[2]](diffhunk://#diff-265d68ce1eaf6a451a0401725ddcf17402b94acacf81197f988a7af04734b194R1-R11)

**Development environment support**

- Updates devcontainer configuration to include the Terraform CLI for local development and automation. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R20-R22) [[2]](diffhunk://#diff-cd9c61f8ff24fb9bcc3663e346e2cfa419cfb84e02aae18d3dc66dd192681696R12-R16)

**Terraform provider management**

- Adds lockfiles for the Cloudflare Terraform provider to ensure reproducible builds for both the account and zone stacks.

These changes lay the groundwork for infrastructure-as-code management of Cloudflare DNS and R2 resources, supporting modular, secure, and reproducible workflows.