### PR TITLE
fix(open-webui): change model to OpenVINO/gemma-4-E4B-it-int4-ov

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -1,7 +1,7 @@
 services:
   ovms:
     command: >
-      --source_model OpenVINO/gemma-4-E4B-it-int8-ov
+      --source_model OpenVINO/gemma-4-E4B-it-int4-ov
       --model_name gemma-4-e4b
       --model_repository_path /models
       --task text_generation


### PR DESCRIPTION
This pull request makes a small update to the `ovms` service configuration in `services/open-webui/compose.yaml`, switching the model precision from int8 to int4 for the `OpenVINO/gemma-4-E4B-it` model.