### PR TITLE
feat(open-webui): increase cache size from 8 to 24

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -8,7 +8,7 @@ services:
       --target_device GPU
       --rest_port 8000
       --max_num_batched_tokens 32768
-      --cache_size 8
+      --cache_size 24
     container_name: ovms
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This pull request makes a minor configuration update to the `services/open-webui/compose.yaml` file, increasing the `--cache_size` parameter for the OVMS service from 8 to 24. This change will allow the service to cache more data, potentially improving performance.