### PR TITLE
feat(open-webui): replace to e2b

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -1,8 +1,8 @@
 services:
   ovms:
     command: >
-      --source_model OpenVINO/gemma-4-31B-it-int4-ov
-      --model_name gemma-4-31b
+      --source_model OpenVINO/gemma-4-E2B-it-int4-ov
+      --model_name gemma-4-e2b
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request updates the configuration for the `ovms` service to use a different model variant for text generation. The change ensures that the service now loads the `gemma-4-e2b` model instead of the previous `gemma-4-31b` model.

Model configuration update:

* Changed the `--source_model` and `--model_name` parameters in `services/open-webui/compose.yaml` to use `OpenVINO/gemma-4-E2B-it-int4-ov` and `gemma-4-e2b`, respectively, replacing the previous `gemma-4-31B-it-int4-ov` and `gemma-4-31b`.