### PR TITLE
fix(open-webui): add `--overwrite_models`

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -9,6 +9,7 @@ services:
       --rest_port 8000
       --max_num_batched_tokens 32768
       --cache_size 24
+      --overwrite_models
     container_name: ovms
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This pull request introduces a small configuration update to the `open-webui` service in the `compose.yaml` file. The change adds the `--overwrite_models` flag to the service's command line arguments, which will allow existing models to be overwritten during service startup.