### PR TITLE
fix(open-webui): reduce cache size from 24 to 8

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -8,7 +8,7 @@ services:
       --target_device GPU
       --rest_port 8000
       --max_num_batched_tokens 32768
-      --cache_size 24
+      --cache_size 8
     container_name: ovms
     devices:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
This pull request makes a minor change to the `services/open-webui/compose.yaml` file, reducing the `--cache_size` parameter for the OVMS service from 24 to 8. This adjustment likely aims to optimize memory usage or resource allocation for the service.