### PR TITLE
fix(open-webui): change model to `OpenVINO/gemma-3-4b-it-int4-ov`

### DIFF
--- a/services/open-webui/compose.yaml
+++ b/services/open-webui/compose.yaml
@@ -1,8 +1,8 @@
 services:
   ovms:
     command: >
-      --source_model durgasai299792458/gemma-4-E2B-OpenVINO-INT4
-      --model_name gemma-4-e2b
+      --source_model OpenVINO/gemma-3-4b-it-int4-ov
+      --model_name gemma-3-4b
       --model_repository_path /models
       --task text_generation
       --target_device GPU


### PR DESCRIPTION
This pull request updates the OpenVINO model configuration in the `compose.yaml` file for the `ovms` service. The new configuration switches to a different source model and updates the model name to match.

- Model configuration update:
  * Changed the `--source_model` parameter from `durgasai299792458/gemma-4-E2B-OpenVINO-INT4` to `OpenVINO/gemma-3-4b-it-int4-ov` and updated the `--model_name` from `gemma-4-e2b` to `gemma-3-4b` in the `ovms` service configuration in `compose.yaml`.