### PR TITLE
feat(roonserver): add initial docker-compose configuration for Roon server

### DIFF
--- a/services/roonserver/compose.yaml
+++ b/services/roonserver/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  roonserver:
+    container_name: roonserver
+    environment:
+      ROON_INSTALL_BRANCH: production
+    image: ghcr.io/roonlabs/roonserver:1.0.7@sha256:8deef4b11e04b869b0f33d1a216f27a0cd83106f1548a4dc3c666300f3be4652
+    network_mode: host
+    restart: always
+    volumes:
+      - roon-data:/Roon
+      - ${ROON_SERVER_MUSIC_DIR}:/Music
+      - ${ROON_SERVER_BACKUP_DIR}:/RoonBackups
+
+volumes:
+  roon-data:


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for deploying the `roonserver` service. The configuration specifies the image, environment variables, networking, restart policy, and required volumes.

Key additions:

**RoonServer Service Deployment:**

* Added a new `compose.yaml` file defining the `roonserver` service, including container image, environment variable (`ROON_INSTALL_BRANCH`), and host network mode.
* Configured persistent storage by mounting volumes for Roon data, music, and backups, with support for environment variable overrides for music and backup directories.
* Set the service to always restart to improve reliability.