### PR TITLE
feat(roonserver): implement text log shipping to central loki

### DIFF
--- a/services/grafana/compose.yaml
+++ b/services/grafana/compose.yaml
@@ -90,6 +90,9 @@ services:
     command: -config.file=/etc/loki/local-config.yaml
     container_name: loki
     image: grafana/loki:3.7.2@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
+    networks:
+      - default
+      - stzky-ingress
     restart: always
     volumes:
       - ./config/loki:/etc/loki:ro

--- a/services/roonserver/compose.yaml
+++ b/services/roonserver/compose.yaml
@@ -11,5 +11,20 @@ services:
       - ${ROON_SERVER_MUSIC_DIR}:/Music
       - ${ROON_SERVER_BACKUP_DIR}:/RoonBackups
 
+  alloy:
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - /etc/alloy/config.alloy
+    container_name: roonserver_alloy
+    image: grafana/alloy:v1.16.2@sha256:32913cbfac652d15fa84d256a74e5ee3f71575961bb19d34796ce3838bfba693
+    networks:
+      - stzky-ingress
+    restart: always
+    user: '0'
+    volumes:
+      - roon-data:/Roon:ro
+      - ./config/alloy:/etc/alloy:ro
+
 volumes:
   roon-data:

--- a/services/roonserver/config/alloy/config.alloy
+++ b/services/roonserver/config/alloy/config.alloy
@@ -1,0 +1,20 @@
+local.file_match "roonserver_logs" {
+  path_targets = [
+    {
+      "__path__"     = "/Roon/database/RoonServer/Logs/RoonServer_log*.txt",
+      "job"          = "roon-server",
+      "service_name" = "roonserver",
+    },
+  ]
+}
+
+loki.source.file "roonserver_files" {
+  targets    = local.file_match "roonserver_logs".output
+  forward_to = [loki.write.ingress_loki.receiver]
+}
+
+loki.write "ingress_loki" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}


### PR DESCRIPTION
This pull request adds log forwarding for the RoonServer service by introducing a new Alloy service and configuration. The changes enable collecting RoonServer logs and forwarding them to Loki for centralized log management.

**Log Forwarding for RoonServer:**

* Added a new `alloy` service to `roonserver`'s `compose.yaml`, which runs the Grafana Alloy container, mounts the necessary configuration and data, and connects to the `stzky-ingress` network.
* Introduced an Alloy configuration file (`config.alloy`) that matches RoonServer log files, defines a Loki source, and forwards logs to the Loki instance.

**Networking Updates:**

* Updated the Loki service in its `compose.yaml` to join the `stzky-ingress` network, ensuring connectivity for log ingestion from Alloy.