### PR TITLE
fix(roonserver): add external network

### DIFF
--- a/services/roonserver/compose.yaml
+++ b/services/roonserver/compose.yaml
@@ -28,3 +28,7 @@ services:
 
 volumes:
   roon-data:
+
+networks:
+  stzky-ingress:
+    external: true


### PR DESCRIPTION
This pull request makes a small update to the `services/roonserver/compose.yaml` file by adding a new external network configuration. This allows the service to connect to the `stzky-ingress` network, which is managed outside of this compose file.

* Added an external network definition for `stzky-ingress` to enable service connectivity with other services or infrastructure on that network.