### PR TITLE
fix(roonserver): simplify log file match configuration

### DIFF
--- a/services/roonserver/config/alloy/config.alloy
+++ b/services/roonserver/config/alloy/config.alloy
@@ -1,15 +1,11 @@
 local.file_match "roonserver_logs" {
   path_targets = [
-    {
-      "__path__"     = "/Roon/database/RoonServer/Logs/RoonServer_log*.txt",
-      "job"          = "roon-server",
-      "service_name" = "roonserver",
-    },
+    {__path__ = "/Roon/database/RoonServer/Logs/RoonServer_log*.txt"},
   ]
 }
 
 loki.source.file "roonserver_files" {
-  targets    = local.file_match "roonserver_logs".output
+  targets    = local.file_match.roonserver_logs.targets
   forward_to = [loki.write.ingress_loki.receiver]
 }
 


### PR DESCRIPTION
This pull request makes minor adjustments to the RoonServer log configuration to simplify and standardize how log file targets are defined and referenced.

- Simplified the `path_targets` definition in `local.file_match "roonserver_logs"` by removing unnecessary metadata fields, leaving only the `__path__` key.
- Updated the reference to the log file targets in `loki.source.file "roonserver_files"` to use the new output structure.