### PR TITLE
feat(compose): add healthchecks to CI-tested services

### DIFF
--- a/services/caddy/compose.test.yaml
+++ b/services/caddy/compose.test.yaml
@@ -1,10 +1,5 @@
 services:
   caddy:
-    healthcheck:
-      test: ['CMD', 'caddy', 'version']
-      interval: 10s
-      timeout: 5s
-      retries: 5
     ports: []
     volumes:
       - ./config/caddy/Caddyfile.test:/etc/caddy/Caddyfile:ro

--- a/services/caddy/compose.yaml
+++ b/services/caddy/compose.yaml
@@ -11,6 +11,11 @@ services:
       MCP_ACCESS_TOKEN: ${MCP_ACCESS_TOKEN}
       PROMETHEUS_HASHED_PASSWORD: ${PROMETHEUS_HASHED_PASSWORD}
       PROMETHEUS_AUTH_USERNAME: ${ALLOY_PROMETHEUS_USERNAME}
+    healthcheck:
+      interval: 10s
+      retries: 5
+      test: ['CMD', 'caddy', 'version']
+      timeout: 5s
     image: ghcr.io/ykzts/caddy
     networks:
       - default

--- a/services/firecrawl/compose.yaml
+++ b/services/firecrawl/compose.yaml
@@ -17,6 +17,12 @@ services:
       POSTGRES_PASSWORD: ${FIRECRAWL_POSTGRES_PASSWORD:-firecrawl_password}
       POSTGRES_DB: ${FIRECRAWL_POSTGRES_DB:-firecrawl}
       BULL_AUTH_KEY: ${FIRECRAWL_BULL_AUTH_KEY:-CHANGEME}
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 60s
+      test: ['CMD', 'node', '-e', 'fetch(''http://127.0.0.1:3002/e2e-test'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))']
+      timeout: 5s
     depends_on:
       firecrawl-redis:
         condition: service_started
@@ -42,6 +48,12 @@ services:
     environment:
       PORT: 3000
     cpus: 1
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'node', '-e', 'fetch(''http://127.0.0.1:3000/health'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))']
+      timeout: 5s
     init: true
     mem_limit: 2g
     restart: always
@@ -53,6 +65,11 @@ services:
     container_name: firecrawl-redis
     cpus: 1
     image: redis:8.8-alpine@sha256:09160599abd229764c0fb44cb6be640294e1d360a54b19985ab4843dcf2d90f1
+    healthcheck:
+      interval: 5s
+      retries: 5
+      test: ['CMD', 'redis-cli', 'ping']
+      timeout: 5s
     init: true
     mem_limit: 1g
     restart: always

--- a/services/grafana/compose.yaml
+++ b/services/grafana/compose.yaml
@@ -9,6 +9,12 @@ services:
     environment:
       ALLOY_PROMETHEUS_PASSWORD: ${ALLOY_PROMETHEUS_PASSWORD}
       ALLOY_PROMETHEUS_USERNAME: ${ALLOY_PROMETHEUS_USERNAME}
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'bash', '-c', 'exec 3<>/dev/tcp/127.0.0.1/12345 && printf "GET /-/ready HTTP/1.0\r\n\r\n" >&3 && head -1 <&3 | grep -q 200']
+      timeout: 5s
     image: grafana/alloy:v1.17.0@sha256:41c41849989b7e054ccbadc17938ee1e5592fe26bfbc56ef3ffc109c0b0b2739
     networks:
       - default
@@ -77,6 +83,12 @@ services:
       GF_SMTP_USER: ${GF_SMTP_FROM_NAME}
       GF_SNAPSHOTS_EXTERNAL_ENABLED: false
       GF_USERS_DEFAULT_THEME: system
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:3000/api/health']
+      timeout: 5s
     image: grafana/grafana:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     networks:
       - default
@@ -89,6 +101,12 @@ services:
   loki:
     command: -config.file=/etc/loki/local-config.yaml
     container_name: loki
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', '/bin/loki', '-health']
+      timeout: 10s
     image: grafana/loki:3.7.2@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
     networks:
       - default
@@ -121,6 +139,12 @@ services:
       - --web.enable-lifecycle
       - --web.enable-remote-write-receiver
     container_name: prometheus
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 10s
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:9090/-/healthy']
+      timeout: 5s
     image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
     networks:
       - default

--- a/services/grafana/compose.yaml
+++ b/services/grafana/compose.yaml
@@ -87,7 +87,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 30s
-      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:3000/api/health']
+      test: ['CMD', 'wget', '--spider', '-q', '--tries=1', 'http://127.0.0.1:3000/api/health']
       timeout: 5s
     image: grafana/grafana:13.0.2@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
     networks:
@@ -143,7 +143,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 10s
-      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:9090/-/healthy']
+      test: ['CMD', 'wget', '--spider', '-q', '--tries=1', 'http://127.0.0.1:9090/-/healthy']
       timeout: 5s
     image: prom/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
     networks:

--- a/services/homepage/compose.yaml
+++ b/services/homepage/compose.yaml
@@ -4,6 +4,12 @@ services:
     environment:
       HOMEPAGE_ALLOWED_HOSTS: stzky.com
       LOG_TARGETS: stdout
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 20s
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://127.0.0.1:3000/api/healthcheck']
+      timeout: 3s
     image: ghcr.io/gethomepage/homepage:v1.13.1@sha256:d8d784e5090111b6e4c56dfd90e272d2953a2094e87349f647165df0fa6c4401
     networks:
       - default

--- a/services/mcp-gateway/compose.yaml
+++ b/services/mcp-gateway/compose.yaml
@@ -17,7 +17,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 30s
-      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8811/healthz']
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8811/health']
       timeout: 5s
     restart: always
 
@@ -62,7 +62,7 @@ services:
     healthcheck:
       interval: 10s
       retries: 5
-      test: ['CMD', 'kill', '-0', '1']
+      test: ['CMD', 'sh', '-c', 'kill -0 1']
       timeout: 5s
     networks:
       - default

--- a/services/mcp-gateway/compose.yaml
+++ b/services/mcp-gateway/compose.yaml
@@ -17,7 +17,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 30s
-      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8811/health']
+      test: ['CMD', 'wget', '--spider', '-q', '--tries=1', 'http://127.0.0.1:8811/health']
       timeout: 5s
     restart: always
 

--- a/services/mcp-gateway/compose.yaml
+++ b/services/mcp-gateway/compose.yaml
@@ -13,6 +13,12 @@ services:
     depends_on:
       - mcp-firecrawl
       - mcp-grafana
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:8811/healthz']
+      timeout: 5s
     restart: always
 
   mcp-firecrawl:
@@ -22,6 +28,11 @@ services:
     environment:
       FIRECRAWL_API_URL: ${FIRECRAWL_API_URL:-http://firecrawl:3002}
       FIRECRAWL_API_KEY: ${FIRECRAWL_API_KEY:-}
+    healthcheck:
+      interval: 10s
+      retries: 5
+      test: ['CMD', 'node', '-e', 'process.kill(1,0)']
+      timeout: 5s
     networks:
       - default
       - stzky-ingress
@@ -48,6 +59,11 @@ services:
     environment:
       GRAFANA_API_URL: ${GRAFANA_API_URL:-http://grafana:3000}
       GRAFANA_SERVICE_ACCOUNT_TOKEN: ${GRAFANA_SERVICE_ACCOUNT_TOKEN:-}
+    healthcheck:
+      interval: 10s
+      retries: 5
+      test: ['CMD', 'kill', '-0', '1']
+      timeout: 5s
     networks:
       - default
       - stzky-ingress

--- a/services/n8n/compose.yaml
+++ b/services/n8n/compose.yaml
@@ -27,6 +27,12 @@ services:
       N8N_SMTP_USER: ${N8N_SMTP_USER:-}
       VUE_APP_URL_BASE_API: https://flow.stzky.com
       WEBHOOK_URL: https://flow.stzky.com
+    healthcheck:
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:5678/healthz']
+      timeout: 5s
     networks:
       - default
       - stzky-ingress

--- a/services/n8n/compose.yaml
+++ b/services/n8n/compose.yaml
@@ -31,7 +31,7 @@ services:
       interval: 10s
       retries: 5
       start_period: 30s
-      test: ['CMD', 'wget', '--spider', '-q', 'http://127.0.0.1:5678/healthz']
+      test: ['CMD', 'wget', '--spider', '-q', '--tries=1', 'http://127.0.0.1:5678/healthz']
       timeout: 5s
     networks:
       - default


### PR DESCRIPTION
## 概要

Issue #418 の対応として、CI テスト対象の主要サービスに `healthcheck` を追加し、コンテナの `running` 状態だけでなくアプリケーションの起動完了を検証できるようにします。

## 変更内容

| サービス | ヘルスチェック |
|---|---|
| `homepage` | `GET /api/healthcheck` |
| `n8n` | `GET /healthz` |
| `caddy` | `caddy version`（本番 `compose.yaml` に移動） |
| `mcp-gateway` | `GET /healthz` |
| `mcp-firecrawl` / `mcp-grafana` | プロセス生存確認（stdio 専用のため HTTP なし） |
| `firecrawl` | `GET /e2e-test` |
| `firecrawl-playwright` | `GET /health` |
| `firecrawl-redis` | `redis-cli ping` |
| `grafana` | `GET /api/health` |
| `alloy` | `GET /-/ready` |
| `loki` | `loki -health` |
| `prometheus` | `GET /-/healthy` |

## 除外

- **`epub-web`**: distroless イメージに HTTP クライアントがなく、追加ビルドなしではコンテナ内プローブ不可。別 issue で追跡予定。

## 検証

- [x] `yamlfmt .`
- [x] `docker compose config`（対象サービス）
- [x] `homepage`, `n8n` のローカル起動で `healthy` を確認
- [ ] CI（`test.yml`）の全サービス `healthy` 確認

Closes #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数のサービスコンテナにヘルスチェック機能を追加しました。各サービスの稼働状態を定期的に監視するための設定が実装されています。対象サービスは Caddy、Firecrawl、Grafana、Homepage、MCP Gateway、N8n です。これにより、システムの信頼性と可用性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->