### PR TITLE
feat(baserow): add baserow to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         id: filter
         with:
           filters: |
+            baserow:
+              - 'services/baserow/**'
             caddy:
               - 'services/caddy/**'
             epub-web:
@@ -47,6 +49,7 @@ jobs:
       - name: Set test matrix
         id: set-matrix
         env:
+          FILTER_BASEROW: ${{ steps.filter.outputs.baserow }}
           FILTER_CADDY: ${{ steps.filter.outputs.caddy }}
           FILTER_EPUB_WEB: ${{ steps.filter.outputs.epub-web }}
           FILTER_FIRECRAWL: ${{ steps.filter.outputs.firecrawl }}
@@ -58,9 +61,10 @@ jobs:
           FILTER_SHARED: ${{ steps.filter.outputs.shared }}
         run: |
           if [ "$FILTER_SHARED" = "true" ]; then
-            matrix='["caddy","epub-web","firecrawl","grafana","homepage","immich","mcp-gateway","n8n"]'
+            matrix='["baserow","caddy","epub-web","firecrawl","grafana","homepage","immich","mcp-gateway","n8n"]'
           else
             selected=()
+            [ "$FILTER_BASEROW" = "true" ] && selected+=(baserow)
             [ "$FILTER_CADDY" = "true" ] && selected+=(caddy)
             [ "$FILTER_EPUB_WEB" = "true" ] && selected+=(epub-web)
             [ "$FILTER_FIRECRAWL" = "true" ] && selected+=(firecrawl)

--- a/services/baserow/README.md
+++ b/services/baserow/README.md
@@ -26,4 +26,5 @@ Baserow関連サービスのCompose設定です。
 ## ファイル
 
 - Compose定義: `compose.yaml`
+- テスト用環境変数: `.env.test`（`BASEROW_JWT_SIGNING_KEY`、`SECRET_KEY` など CI 用のダミー値）
 


### PR DESCRIPTION
## 概要

`baserow` を GitHub Actions の Compose テスト対象に追加します。

Closes #417

## 変更内容

- `.github/workflows/test.yml` のパスフィルターとテストマトリクスに `baserow` を追加
- `services/baserow/README.md` に `.env.test` の説明を追記

## 背景

`baserow` は `BASEROW_JWT_SIGNING_KEY` と `SECRET_KEY` が必須のため、環境変数なしでは `docker compose config` が失敗していました。既存の `.env.test` を `COMPOSE_ENV_FILES` で読み込むことで、CI から起動・ヘルスチェックできるようにします。

## 検証

- [x] `COMPOSE_ENV_FILES=.env.test docker compose -f services/baserow/compose.yaml config`
- [x] ローカルで `docker compose up -d` 後、全 7 コンテナが healthy になることを確認（約 105 秒）
- [x] `yamlfmt .`
- [ ] GitHub Actions 上での CI 実行（PR マージ前に確認）

## 備考

`compose.test.yaml` はローカル検証で不要と判断したため追加していません。起動に時間がかかる場合は、後続でタイムアウト調整やテスト用オーバーライドを検討できます。