### PR TITLE
build(deps): update docker.n8n.io/n8nio/n8n docker tag to 2.27.4

### DIFF
--- a/services/n8n/compose.yaml
+++ b/services/n8n/compose.yaml
@@ -4,7 +4,7 @@ services:
     depends_on:
       n8n-db:
         condition: service_healthy
-    image: docker.n8n.io/n8nio/n8n:2.21.7@sha256:9f1f8e4c093c9924338bd168e3f813f746041d13b337753af0dbdd329e7b50f7
+    image: docker.n8n.io/n8nio/n8n:2.27.4@sha256:cf11c96b0d0089bb24459bf97b445fd7008f41543b673cce4d955f7c0ed8752d
     environment:
       DB_POSTGRESDB_HOST: n8n-db
       DB_POSTGRESDB_DATABASE: ${POSTGRES_DB:-n8n}


### PR DESCRIPTION
## 概要

n8n の Docker イメージを `2.21.7` から `2.27.4` に更新します。

| Package | Update | Change |
|---|---|---|
| [docker.n8n.io/n8nio/n8n](https://n8n.io) | minor | `2.21.7` → `2.27.4` |

## 変更内容

- `services/n8n/compose.yaml` の `n8n` イメージタグと digest を更新

## 想定影響

- n8n コンテナの再作成が必要
- PostgreSQL (`n8n-db`) は変更なし
- マイグレーションが発生する場合は n8n 起動時に自動実行される

## 検証

実施済み:

- `yamlfmt .`
- `docker compose -f services/n8n/compose.yaml config`
- CI と同等のヘルスチェック（`COMPOSE_ENV_FILES=.env.test` で `docker compose up -d`、全サービス `healthy` 待機）
- `/healthz` エンドポイント確認
- `n8n --version` で `2.27.4` を確認

未実施:

- 本番環境での再起動・ワークフロー動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * サービスのコンテナイメージが新しいバージョンに更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->