### PR TITLE
feat(caddy): remove auth for mcp-gateway

### DIFF
--- a/services/caddy/config/caddy/Caddyfile
+++ b/services/caddy/config/caddy/Caddyfile
@@ -101,15 +101,7 @@ stzky.com, *.stzky.com {
 
 	@mcp host mcp.stzky.com
 	handle @mcp {
-		@unauthorized {
-			not header_regexp auth Authorization `^(?i:Bearer)\s+{$MCP_ACCESS_TOKEN}$`
-		}
-
-		handle @unauthorized {
-			header Content-Type application/json
-			respond `{"error": "Unauthorized", "message": "Valid token required"}` 401
-		}
-
+		encode zstd gzip
 		reverse_proxy gateway:8811
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * MCPエンドポイントでレスポンス圧縮を有効化し、通信効率を改善しました。
* **変更**
  * 認証失敗時の固定エラーレスポンス表示を削除し、リクエストは後続の処理へ進むようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->